### PR TITLE
Add eslint and fix lint warnings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+  "extends": "google",
+  "installedESLint": true,
+  // http://eslint.org/docs/rules/
+  "rules": {
+    "require-jsdoc": 0
+  },
+  // http://eslint.org/docs/user-guide/configuring#specifying-environments
+  "env": {
+  }
+}

--- a/app.js
+++ b/app.js
@@ -32,17 +32,17 @@ app.use('/pwas', require('./pwas/crud'));
 app.use('/api/pwas', require('./pwas/api'));
 
 // Redirect root to /pwas
-app.get('/', function (req, res) {
+app.get('/', function(req, res) {
   res.redirect('/pwas');
 });
 
 // Basic 404 handler
-app.use(function (req, res) {
+app.use(function(req, res) {
   res.status(404).send('Not Found');
 });
 
 // Basic error handler
-app.use(function (err, req, res, next) {
+app.use(function(err, req, res, next) {
   /* jshint unused:false */
   console.error(err);
   // If our routes specified a specific response, then send that. Otherwise,
@@ -52,7 +52,7 @@ app.use(function (err, req, res, next) {
 
 if (module === require.main) {
   // Start the server
-  var server = app.listen(config.get('PORT'), function () {
+  var server = app.listen(config.get('PORT'), function() {
     var port = server.address().port;
     console.log('App listening on port %s', port);
   });

--- a/config/config.js
+++ b/config/config.js
@@ -29,7 +29,7 @@ nconf
     'PORT'
   ])
   // 3. Config file
-  .file({ file: path.join(__dirname, 'config.json') })
+  .file({file: path.join(__dirname, 'config.json')})
   // 4. Defaults
   .defaults({
     // Typically you will create a bucket with the same name as your project ID.
@@ -47,7 +47,7 @@ nconf
 checkConfig('GCLOUD_PROJECT');
 checkConfig('CLOUD_BUCKET');
 
-function checkConfig (setting) {
+function checkConfig(setting) {
   if (!nconf.get(setting)) {
     throw new Error('You must set the ' + setting + ' environment variable or' +
       ' add it to config.json!');

--- a/pwas/api.js
+++ b/pwas/api.js
@@ -23,7 +23,7 @@ function getModel() {
   return require('../lib/model-' + config.get('DATA_BACKEND'));
 }
 
-var router = express.Router();
+var router = express.Router(); // eslint-disable-line
 
 // Automatically parse request body as JSON
 router.use(bodyParser.json());
@@ -34,7 +34,7 @@ router.use(bodyParser.json());
  * Retrieve a page of PWAs (up to ten at a time).
  */
 router.get('/', function list(req, res, next) {
-  getModel().list(PWA, 10, req.query.pageToken, function(err, entities, cursor) {
+  function callback(err, entities, cursor) {
     if (err) {
       return next(err);
     }
@@ -42,7 +42,8 @@ router.get('/', function list(req, res, next) {
       items: entities,
       nextPageToken: cursor
     });
-  });
+  }
+  getModel().list(PWA, 10, req.query.pageToken, callback);
 });
 
 /**

--- a/pwas/crud.js
+++ b/pwas/crud.js
@@ -24,7 +24,7 @@ function getModel() {
   return require('../lib/model-' + config.get('DATA_BACKEND'));
 }
 
-var router = express.Router();
+var router = express.Router(); // eslint-disable-line
 
 // Set Content-Type for all responses for these routes
 router.use(function(req, res, next) {
@@ -38,7 +38,7 @@ router.use(function(req, res, next) {
  * Display a page of PWAs (up to ten at a time).
  */
 router.get('/', function list(req, res, next) {
-  getModel().list(PWA, 10, req.query.pageToken, function(err, entities, cursor) {
+  function callback(err, entities, cursor) {
     if (err) {
       return next(err);
     }
@@ -46,7 +46,8 @@ router.get('/', function list(req, res, next) {
       pwas: entities,
       nextPageToken: cursor
     });
-  });
+  }
+  getModel().list(PWA, 10, req.query.pageToken, callback);
 });
 
 /**
@@ -135,6 +136,9 @@ router.post(
         console.log(json);
         data.manifest = JSON.stringify(json);
         getModel().update(PWA, req.params.pwa, data, function(err, savedData) {
+          if (err) {
+            return;
+          }
         });
       });
     });


### PR DESCRIPTION
Have globally disabled the require-jsdoc rule, and also (in two places) the requirement that functions with capital letters should only be used as constructors. (express wants to do this.)