### PR TITLE
Update CI config to use Trusty image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+dist: trusty
 node_js:
   - "6"
   - "4"


### PR DESCRIPTION
The builds (in my fork) [are failing](https://travis-ci.org/ithinkihaveacat/gulliver/jobs/144720320), I think because some node modules can't be built. Updating to a Debian "trusty" build is [supposed to fix it](https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements).