### PR TITLE
Add sudo: required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+sudo: required
 dist: trusty
 node_js:
   - "6"


### PR DESCRIPTION
Unfortunately for some reason we need both `dist: trusty` *and* `sudo: required` to get [the Trusty beta build environment](https://docs.travis-ci.com/user/trusty-ci-environment/)...