### PR TITLE
Fix crash when PWA is added/created

### DIFF
--- a/lib/model-datastore.js
+++ b/lib/model-datastore.js
@@ -120,7 +120,9 @@ function update(kind, id, data, cb) {
     entity,
     function(err) {
       data.id = entity.key.id;
-      cb(err, err ? null : data);
+      if (cb) {
+        cb(err, err ? null : data);
+      }
     }
   );
 }


### PR DESCRIPTION
Creating a PWA crashes the server for me, I think because [crud.js#L87](https://github.com/GoogleChrome/gulliver/blob/master/controllers/pwas/crud.js#L87) doesn't actually pass a callback.