### PR TITLE
Use SVG for PWA image

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,7 +19,7 @@ const path = require('path');
 const express = require('express');
 const config = require('./config/config');
 const hbs = require('hbs');
-
+const helpers = require('./views/helpers');
 const app = express();
 
 app.disable('etag');
@@ -27,6 +27,7 @@ app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'hbs');
 app.set('trust proxy', true);
 hbs.registerPartials(path.join(__dirname, '/views/includes/'));
+helpers.registerHelpers(hbs);
 
 // Static files
 app.use(express.static('public'));

--- a/controllers/pwas/crud.js
+++ b/controllers/pwas/crud.js
@@ -31,6 +31,11 @@ router.get('/', (req, res, next) => {
     if (err) {
       return next(err);
     }
+
+    for (let pwa of entities) {
+      pwa.firstletter = pwa.name[0];
+    }
+
     res.render('pwas/list.hbs', {
       pwas: entities,
       nextPageToken: cursor
@@ -132,6 +137,7 @@ router.get('/:pwa', (req, res, next) => {
       return next(err);
     }
 
+    entity.firstletter = entity.name[0];
     res.render('pwas/view.hbs', {
       pwa: entity
     });

--- a/controllers/pwas/crud.js
+++ b/controllers/pwas/crud.js
@@ -21,6 +21,17 @@ const pwaModel = require('../../models/pwa');
 const router = express.Router(); // eslint-disable-line new-cap
 const LIST_PAGE_SIZE = 10;
 
+function getContrastYIQ(hexcolor) {
+  if (hexcolor[0] === '#') {
+    hexcolor = hexcolor.substr(1, hexcolor.length);
+  }
+  const r = parseInt(hexcolor.substr(0, 2), 16);
+  const g = parseInt(hexcolor.substr(2, 2), 16);
+  const b = parseInt(hexcolor.substr(4, 2), 16);
+  const yiq = ((r * 299) + (g * 587) + (b * 114)) / 1000;
+  return (yiq >= 128) ? 'black' : 'white';
+}
+
 /**
  * GET /pwas/add
  *
@@ -34,6 +45,7 @@ router.get('/', (req, res, next) => {
 
     for (let pwa of entities) {
       pwa.firstletter = pwa.name[0];
+      pwa.fgcolor = getContrastYIQ(pwa.backgroundColor);
     }
 
     res.render('pwas/list.hbs', {
@@ -138,6 +150,7 @@ router.get('/:pwa', (req, res, next) => {
     }
 
     entity.firstletter = entity.name[0];
+    entity.fgcolor = getContrastYIQ(entity.backgroundColor);
     res.render('pwas/view.hbs', {
       pwa: entity
     });

--- a/controllers/pwas/crud.js
+++ b/controllers/pwas/crud.js
@@ -21,17 +21,6 @@ const pwaModel = require('../../models/pwa');
 const router = express.Router(); // eslint-disable-line new-cap
 const LIST_PAGE_SIZE = 10;
 
-function getContrastYIQ(hexcolor) {
-  if (hexcolor[0] === '#') {
-    hexcolor = hexcolor.substr(1, hexcolor.length);
-  }
-  const r = parseInt(hexcolor.substr(0, 2), 16);
-  const g = parseInt(hexcolor.substr(2, 2), 16);
-  const b = parseInt(hexcolor.substr(4, 2), 16);
-  const yiq = ((r * 299) + (g * 587) + (b * 114)) / 1000;
-  return (yiq >= 128) ? 'black' : 'white';
-}
-
 /**
  * GET /pwas/add
  *
@@ -41,11 +30,6 @@ router.get('/', (req, res, next) => {
   function callback(err, entities, cursor) {
     if (err) {
       return next(err);
-    }
-
-    for (let pwa of entities) {
-      pwa.firstletter = pwa.name[0];
-      pwa.fgcolor = getContrastYIQ(pwa.backgroundColor);
     }
 
     res.render('pwas/list.hbs', {
@@ -149,8 +133,6 @@ router.get('/:pwa', (req, res, next) => {
       return next(err);
     }
 
-    entity.firstletter = entity.name[0];
-    entity.fgcolor = getContrastYIQ(entity.backgroundColor);
     res.render('pwas/view.hbs', {
       pwa: entity
     });

--- a/models/pwa.js
+++ b/models/pwa.js
@@ -79,6 +79,10 @@ exports.save = function(pwa, callback) {
       if (err) {
         return callback(err);
       }
+
+      pwa.name = manifest.name;
+      pwa.startUrl = manifest.start_url || '';
+      pwa.backgroundColor = manifest.background_color || '#ffffff';
       pwa.manifest = JSON.stringify(manifest);
       db.update(ENTITY_NAME, pwa.id, pwa, callback);
     });

--- a/views/helpers/index.js
+++ b/views/helpers/index.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2015-2016, Google, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+exports.registerHelpers = function(hbs) {
+  hbs.registerHelper('firstLetter', text => {
+    return text ? text[0] : '';
+  });
+
+  hbs.registerHelper('contrastColor', hexcolor => {
+    if (hexcolor[0] === '#') {
+      hexcolor = hexcolor.substr(1, hexcolor.length);
+    }
+    const r = parseInt(hexcolor.substr(0, 2), 16);
+    const g = parseInt(hexcolor.substr(2, 2), 16);
+    const b = parseInt(hexcolor.substr(4, 2), 16);
+    const yiq = ((r * 299) + (g * 587) + (b * 114)) / 1000;
+    return (yiq >= 128) ? 'black' : 'white';
+  });
+};

--- a/views/pwas/list.hbs
+++ b/views/pwas/list.hbs
@@ -27,7 +27,7 @@
                     <div class="media-left">
                         <svg width="64" height="64">
                             <rect width="64" height="64" stroke-width="4" fill="{{backgroundColor}}" />
-                            <text x="32" y="32" fill="{{fgcolor}}" alignment-baseline="middle" text-anchor="middle" font-size="32px">{{firstletter}}</text>                            
+                            <text x="32" y="32" fill="{{contrastColor backgroundColor}}" alignment-baseline="middle" text-anchor="middle" font-size="32px">{{firstLetter name}}</text>
                         </svg>                
                     </div>
                     <div class="media-body">

--- a/views/pwas/list.hbs
+++ b/views/pwas/list.hbs
@@ -24,11 +24,15 @@
             {{#each pwas}}
             <div class="media">
                 <a href="/pwas/{{id}}">
-                    <div class="media-left"><img src="/pwa.png">
+                    <div class="media-left">
+                        <svg width="64" height="64">
+                            <rect width="64" height="64" stroke-width="4" fill="{{backgroundColor}}" />
+                            <text x="32" y="32" fill="white" alignment-baseline="middle" text-anchor="middle" font-size="32px">{{firstletter}}</text>                            
+                        </svg>                
                     </div>
                     <div class="media-body">
                         <h4>{{name}}</h4>
-                        <h4>{{manifestUrl}}</h4>
+                        <h5>{{manifestUrl}}</h5>
                         <p>{{startUrl}}</p>
                     </div>
                 </a>

--- a/views/pwas/list.hbs
+++ b/views/pwas/list.hbs
@@ -27,7 +27,7 @@
                     <div class="media-left">
                         <svg width="64" height="64">
                             <rect width="64" height="64" stroke-width="4" fill="{{backgroundColor}}" />
-                            <text x="32" y="32" fill="white" alignment-baseline="middle" text-anchor="middle" font-size="32px">{{firstletter}}</text>                            
+                            <text x="32" y="32" fill="{{fgcolor}}" alignment-baseline="middle" text-anchor="middle" font-size="32px">{{firstletter}}</text>                            
                         </svg>                
                     </div>
                     <div class="media-body">

--- a/views/pwas/view.hbs
+++ b/views/pwas/view.hbs
@@ -33,7 +33,7 @@
                 <div class="media-left">
                     <svg width="256" height="256">
                         <rect width="100%" height="100%" stroke-width="4" fill="{{pwa.backgroundColor}}" />
-                        <text x="50%" y="50%" fill="{{pwa.fgcolor}}" alignment-baseline="middle" text-anchor="middle" font-size="128px">{{pwa.firstletter}}</text>                            
+                        <text x="50%" y="50%" fill="{{contrastColor pwa.backgroundColor}}" alignment-baseline="middle" text-anchor="middle" font-size="128px">{{firstLetter pwa.name}}</text>
                     </svg>                    
                 </div>
                 <div class="media-body">

--- a/views/pwas/view.hbs
+++ b/views/pwas/view.hbs
@@ -30,7 +30,12 @@
                 </a>
             </div>
             <div class="media">
-                <div class="media-left"><img src="/pwa.png"></div>
+                <div class="media-left">
+                    <svg width="256" height="256">
+                        <rect width="100%" height="100%" stroke-width="4" fill="{{pwa.backgroundColor}}" />
+                        <text x="50%" y="50%" fill="white" alignment-baseline="middle" text-anchor="middle" font-size="128px">{{pwa.firstletter}}</text>                            
+                    </svg>                    
+                </div>
                 <div class="media-body">
                     <h4>{{pwa.name}}</h4>
                     <h4>{{pwa.manifestUrl}}</h4>

--- a/views/pwas/view.hbs
+++ b/views/pwas/view.hbs
@@ -33,7 +33,7 @@
                 <div class="media-left">
                     <svg width="256" height="256">
                         <rect width="100%" height="100%" stroke-width="4" fill="{{pwa.backgroundColor}}" />
-                        <text x="50%" y="50%" fill="white" alignment-baseline="middle" text-anchor="middle" font-size="128px">{{pwa.firstletter}}</text>                            
+                        <text x="50%" y="50%" fill="{{pwa.fgcolor}}" alignment-baseline="middle" text-anchor="middle" font-size="128px">{{pwa.firstletter}}</text>                            
                     </svg>                    
                 </div>
                 <div class="media-body">


### PR DESCRIPTION
Using a SVG with background color + first letter of the name of the PWA as the default PWA image. In the future we'll use the PWA icon whenever possible.