### PR TITLE
Set Content-Type to file on GCloud

### DIFF
--- a/lib/images.js
+++ b/lib/images.js
@@ -70,7 +70,7 @@ function saveImage(response, destFile) {
       writeStream.on('finish', () => {
         file.setMetadata({
           contentType: contentType
-        }, (err) => {
+        }, err => {
           if (err) {
             reject(err);
           }

--- a/lib/images.js
+++ b/lib/images.js
@@ -62,11 +62,20 @@ function saveImage(response, destFile) {
       reject(new Error('Bad Response'));
     }
 
+    const contentType = response.headers.get('Content-Type');
     try {
       const file = bucket.file(destFile);
+
       const writeStream = file.createWriteStream();
       writeStream.on('finish', () => {
-        resolve(getPublicUrl(destFile));
+        file.setMetadata({
+          contentType: contentType
+        }, (err) => {
+          if (err) {
+            reject(err);
+          }
+          resolve(getPublicUrl(destFile));
+        });
       });
       response.body.pipe(writeStream);
     } catch (e) {


### PR DESCRIPTION
- Uses the content-type from to response to set the content
  type on the GCloud file.

- The API available needs a second network call. I was looking for
  a way go set the Content-Type when creating the file or streaming
  it, but it seems this is the only way.