### PR TITLE
Set Content-Type when creating WriteStream

### DIFF
--- a/lib/images.js
+++ b/lib/images.js
@@ -66,16 +66,16 @@ function saveImage(response, destFile) {
     try {
       const file = bucket.file(destFile);
 
-      const writeStream = file.createWriteStream();
+      const writeStream = file.createWriteStream({
+        contentType: contentType
+      });
+
+      writeStream.on('error', err => {
+        reject(err);
+      });
+
       writeStream.on('finish', () => {
-        file.setMetadata({
-          contentType: contentType
-        }, err => {
-          if (err) {
-            reject(err);
-          }
-          resolve(getPublicUrl(destFile));
-        });
+        resolve(getPublicUrl(destFile));
       });
       response.body.pipe(writeStream);
     } catch (e) {


### PR DESCRIPTION
- Found a way to set the Content-Type when creating the WriteStream.
  This avoids a second network call and will make uploading the
  image faster.