### PR TITLE
Revert "Set Content-Type when creating WriteStream"

### DIFF
--- a/lib/images.js
+++ b/lib/images.js
@@ -66,16 +66,16 @@ function saveImage(response, destFile) {
     try {
       const file = bucket.file(destFile);
 
-      const writeStream = file.createWriteStream({
-        contentType: contentType
-      });
-
-      writeStream.on('error', err => {
-        reject(err);
-      });
-
+      const writeStream = file.createWriteStream();
       writeStream.on('finish', () => {
-        resolve(getPublicUrl(destFile));
+        file.setMetadata({
+          contentType: contentType
+        }, err => {
+          if (err) {
+            reject(err);
+          }
+          resolve(getPublicUrl(destFile));
+        });
       });
       response.body.pipe(writeStream);
     } catch (e) {


### PR DESCRIPTION
Reverts GoogleChrome/gulliver#51

Doesn't actually work. My browser was caching the file. 