### PR TITLE
Handle manifest errors

### DIFF
--- a/controllers/pwas/crud.js
+++ b/controllers/pwas/crud.js
@@ -72,6 +72,14 @@ router.post('/add', (req, res, next) => {
               error: 'manifest already exists'
             });
             return;
+          case pwaModel.E_MANIFEST_ERROR:
+            res.render('pwas/form.hbs', {
+              pwa: {
+                manifestUrl: data.manifestUrl
+              },
+              error: 'error loading manifest' // could be 404, not JSON, domain does not exist
+            });
+            return;
           default:
         }
       }

--- a/controllers/pwas/crud.js
+++ b/controllers/pwas/crud.js
@@ -62,6 +62,19 @@ router.post('/add', (req, res, next) => {
 
   const callback = (err, savedData) => {
     if (err) {
+      if (typeof err === 'number') {
+        switch (err) {
+          case pwaModel.E_ALREADY_EXISTS:
+            res.render('pwas/form.hbs', {
+              pwa: {
+                manifestUrl: data.manifestUrl
+              },
+              error: 'manifest already exists'
+            });
+            return;
+          default:
+        }
+      }
       return next(err);
     }
     res.redirect(req.baseUrl + '/' + savedData.id);

--- a/models/pwa.js
+++ b/models/pwa.js
@@ -26,6 +26,7 @@ const ds = gcloud.datastore({
 const ENTITY_NAME = 'PWA';
 
 const E_ALREADY_EXISTS = exports.E_ALREADY_EXISTS = 1;
+const E_MANIFEST_ERROR = exports.E_MANIFEST_ERROR = 2;
 
 function mergeManifest(pwa, manifest) {
   pwa.name = manifest.name;
@@ -90,7 +91,7 @@ exports.save = function(pwa, callback) {
 
     Manifest.fetch(pwa.manifestUrl, (err, manifest) => {
       if (err) {
-        return callback(err);
+        return callback(E_MANIFEST_ERROR);
       }
       mergeManifest(pwa, manifest);
       db.update(ENTITY_NAME, pwa.id, pwa)

--- a/models/pwa.js
+++ b/models/pwa.js
@@ -25,6 +25,8 @@ const ds = gcloud.datastore({
 });
 const ENTITY_NAME = 'PWA';
 
+const E_ALREADY_EXISTS = exports.E_ALREADY_EXISTS = 1;
+
 function mergeManifest(pwa, manifest) {
   pwa.name = manifest.name;
   pwa.startUrl = manifest.start_url || '';
@@ -72,7 +74,7 @@ exports.findByManifestUrl = function(manifestUrl, callback) {
 };
 
 exports.save = function(pwa, callback) {
-   // TODO Check manifestUrl with regexp
+  // TODO Check manifestUrl with regexp
   if (!pwa.manifestUrl) {
     return callback('Missing manifestUrl', null);
   }
@@ -83,8 +85,7 @@ exports.save = function(pwa, callback) {
     }
 
     if (existingPwa && (!pwa.id || existingPwa.data.id.toString() !== pwa.id.toString())) {
-      return callback(
-          'Manifest already Registered for a different PWA', null);
+      return callback(E_ALREADY_EXISTS, null);
     }
 
     Manifest.fetch(pwa.manifestUrl, (err, manifest) => {

--- a/views/includes/css.hbs
+++ b/views/includes/css.hbs
@@ -161,6 +161,9 @@ div.pwabox-body a {
     overflow: scroll;
     border: 1px solid lightgray;
 }
+.error {
+  color: #f07;
+}
 
 /* Flex List of PWAs */
 .items {

--- a/views/pwas/form.hbs
+++ b/views/pwas/form.hbs
@@ -30,6 +30,9 @@
       <form method="POST">
         <div class="form-group">
           <label for="manifestUrl">Manifest URL</label>
+          {{#if error}}
+          <p class="error">Error: {{error}}.</p>
+          {{/if}}
           <input type="text" name="manifestUrl" id="manifestUrl" class="form-input" value="{{pwa.manifestUrl}}">
         </div>
         {{#if pwa.manifest}}


### PR DESCRIPTION
- Return proper error message if manifest already exists (#61)
- Return proper (though not especially helpful) error message if the manifest couldn't be loaded at all (#64)

This adds the concept of error codes. (Not propagated through the rest of the code.)