### PR TITLE
Improve manifest parsing robustness

### DIFF
--- a/models/pwa.js
+++ b/models/pwa.js
@@ -31,8 +31,8 @@ const E_MANIFEST_ERROR = exports.E_MANIFEST_ERROR = 2;
 
 function mergeManifest(pwa, manifest) {
   pwa.name = manifest.name;
-  pwa.startUrl = manifest.start_url || '';
-  pwa.absoluteStartUrl = uri(manifest.start_url).absoluteTo(manifest.url).toString() || '';
+  pwa.startUrl = manifest.start_url || '/';
+  pwa.absoluteStartUrl = uri(pwa.startUrl).absoluteTo(manifest.url).toString() || '';
   pwa.backgroundColor = manifest.background_color || '#ffffff';
   pwa.manifest = JSON.stringify(manifest);
 }

--- a/test/manifests/no-start-url.json
+++ b/test/manifests/no-start-url.json
@@ -1,0 +1,24 @@
+{
+  "short_name": "LinkedIn SlideShare",
+  "name": "LinkedIn SlideShare",
+  "icons": [
+    {
+      "src": "images/slideshare_icon.png",
+      "sizes": "110x110",
+      "type": "image/png"
+    },
+    {
+      "src": "images/app_icon_square_144x144.png",
+      "sizes": "144x144",
+      "type": "image/png"
+    }
+  ],
+  "display": "browser",
+  "prefer_related_applications": true,
+  "related_applications": [
+    {
+      "platform": "play",
+      "id": "net.slideshare.mobile"
+    }
+  ]
+}


### PR DESCRIPTION
We feel over parsing https://www.slideshare.net/manifest.json, because it doesn't have a `start_url`. This PR fixes this, and also saves the manifest itself for a time when we actually test this stuff.

/cc @adewale 