### PR TITLE
Update PWA when manifest is re-submitted

### DIFF
--- a/controllers/pwas/crud.js
+++ b/controllers/pwas/crud.js
@@ -88,12 +88,6 @@ router.post('/add', (req, res, next) => {
         if (err) {
           if (typeof err === 'number') {
             switch (err) {
-              case pwaLib.E_ALREADY_EXISTS:
-                res.render('pwas/form.hbs', {
-                  pwa,
-                  error: 'manifest already exists'
-                });
-                return;
               case pwaLib.E_MANIFEST_ERROR:
                 res.render('pwas/form.hbs', {
                   pwa,
@@ -114,7 +108,6 @@ router.post('/add', (req, res, next) => {
         pwa,
         error: err
       });
-      console.log(err);
       return;
     });
 });

--- a/lib/pwa.js
+++ b/lib/pwa.js
@@ -26,11 +26,7 @@ const ds = gcloud.datastore({
   projectId: config.get('GCLOUD_PROJECT')
 });
 
-<<<<<<< 0cb8afedbafa68674548b8c5a3ce6b5d1254801f
 const ENTITY_NAME = 'PWA';
-const E_ALREADY_EXISTS = exports.E_ALREADY_EXISTS = 1;
-=======
->>>>>>> Update PWA when manifest is re-submitted
 const E_MANIFEST_ERROR = exports.E_MANIFEST_ERROR = 2;
 
 exports.list = function(numResults, pageToken, callback) {

--- a/lib/pwa.js
+++ b/lib/pwa.js
@@ -26,8 +26,11 @@ const ds = gcloud.datastore({
   projectId: config.get('GCLOUD_PROJECT')
 });
 
+<<<<<<< 0cb8afedbafa68674548b8c5a3ce6b5d1254801f
 const ENTITY_NAME = 'PWA';
 const E_ALREADY_EXISTS = exports.E_ALREADY_EXISTS = 1;
+=======
+>>>>>>> Update PWA when manifest is re-submitted
 const E_MANIFEST_ERROR = exports.E_MANIFEST_ERROR = 2;
 
 exports.list = function(numResults, pageToken, callback) {
@@ -82,8 +85,8 @@ exports.save = function(pwa, callback) {
       return callback(err);
     }
 
-    if (existingPwa && (!pwa.id || existingPwa.id.toString() !== pwa.id.toString())) {
-      return callback(E_ALREADY_EXISTS, null);
+    if (!existingPwa) {
+      existingPwa = pwa;
     }
 
     Manifest.fetch(pwa.manifestUrl, (err, manifest) => {
@@ -91,9 +94,6 @@ exports.save = function(pwa, callback) {
         return callback(E_MANIFEST_ERROR);
       }
 
-      if (!existingPwa) {
-        existingPwa = pwa;
-      }
       existingPwa.mergeManifest(manifest);
 
       // Reading Description from Meta if not present in the Manifest
@@ -107,13 +107,12 @@ exports.save = function(pwa, callback) {
           });
       }
 
-      db.update(ENTITY_NAME, pwa.id, existingPwa)
+      db.update(ENTITY_NAME, existingPwa.id, existingPwa)
         .then(savedPwa => {
           updateIcon(savedPwa, manifest);
           callback(null, savedPwa);
         })
         .catch(err => {
-          console.log(err);
           callback(err);
         });
     });


### PR DESCRIPTION
If a user submits a manifest that already exists, update
the PWA instead of showing an error.

Fixes #75 