### PR TITLE
Use meta / manifest description

### DIFF
--- a/lib/pwa.js
+++ b/lib/pwa.js
@@ -103,7 +103,7 @@ exports.save = function(pwa, callback) {
       if (!existingPwa.description && existingPwa.absoluteStartUrl) {
         dataFetcher.fetchMetadataDescription(existingPwa.absoluteStartUrl)
           .then(description => {
-            existingPwa.description = description;
+            existingPwa.metaDescription = description;
           })
           .catch(err => {
             console.log(err);

--- a/models/pwa.js
+++ b/models/pwa.js
@@ -32,10 +32,11 @@ class Pwa {
   }
 
   get description() {
-    if (!this.manifest) {
-      return '';
+    if (this.manifest && this.manifest.description) {
+      return this.manifest.description;
     }
-    return this.manifest.description || '';
+
+    return this.metaDescription || '';
   }
 
   get startUrl() {

--- a/test/models/pwa.js
+++ b/test/models/pwa.js
@@ -75,4 +75,15 @@ describe('models/pwa.js', () => {
     assert.equal(pwa.createdOn, pwa.updatedOn, 'updatedOn is the same as createdOn');
     assert.ok(pwa.manifestAsString, 'manifestAsString is a non-empty string');
   });
+
+  it('Return the right description', () => {
+    var pwa = new Pwa();
+    assert.equal(pwa.description, '');
+    pwa.metaDescription = 'metaDescription';
+    assert.equal(pwa.description, 'metaDescription');
+    pwa.manifest = {
+      description: 'manifestDescription'
+    };
+    assert.equal(pwa.description, 'manifestDescription');
+  });
 });


### PR DESCRIPTION
Changed description getter to give preference to the manifest
description and use the metaDescription when the first is not
available