### PR TITLE
Show manifest correctly on edit form

### DIFF
--- a/views/pwas/form.hbs
+++ b/views/pwas/form.hbs
@@ -38,7 +38,7 @@
         {{#if pwa.manifest}}
         <div class="form-group">
           <label for="manifest">Manifest content</label>
-          <div class="form-textbox">{{pwa.manifest}}</div>
+          <div class="form-textbox">{{pwa.manifestAsString}}</div>
         </div>
         {{/if}}
         <input id="idToken" type="hidden" name="idToken" />


### PR DESCRIPTION
The code was using `pwa.manifest` that is now an object. Switched to
using `pwa.manifestAsString` instead.

Fixe #98