### PR TITLE
Move client_id into configuration

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,7 +28,12 @@ app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'hbs');
 app.set('trust proxy', true);
 hbs.registerPartials(path.join(__dirname, '/views/includes/'));
+hbs.localsAsTemplateData(app);
 helpers.registerHelpers(hbs);
+
+app.locals.configstring = JSON.stringify({
+  client_id: config.get('CLIENT_ID') // eslint-disable-line camelcase
+});
 
 app.use(bodyParser.urlencoded({extended: true}));
 

--- a/app.js
+++ b/app.js
@@ -28,9 +28,10 @@ app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'hbs');
 app.set('trust proxy', true);
 hbs.registerPartials(path.join(__dirname, '/views/includes/'));
-hbs.localsAsTemplateData(app);
 helpers.registerHelpers(hbs);
 
+// Make variables available to *all* templates
+hbs.localsAsTemplateData(app);
 app.locals.configstring = JSON.stringify({
   client_id: config.get('CLIENT_ID') // eslint-disable-line camelcase
 });

--- a/public/js/gulliver.js
+++ b/public/js/gulliver.js
@@ -97,7 +97,7 @@ function authInit(params) {
   /* eslint-disable camelcase */
   const params = {
     scope: 'profile',
-    client_id: '605287872172-js6omne47i1k79hnfo7d4bdu9rlemslr.apps.googleusercontent.com',
+    client_id: window.__config.client_id,
     fetch_basic_profile: false
   };
   /* eslint-enable camelcase */

--- a/views/includes/head.hbs
+++ b/views/includes/head.hbs
@@ -23,6 +23,7 @@
       resolve(window.gapi);
     };
   });
+  window.__config = {{{@configstring}}};
 </script>
 <script src="https://apis.google.com/js/api.js?onload=gapiResolve" async defer></script>
 <script src="/js/gulliver.js" async defer></script>

--- a/views/includes/head.hbs
+++ b/views/includes/head.hbs
@@ -23,7 +23,7 @@
       resolve(window.gapi);
     };
   });
-  window.__config = {{{@configstring}}};
+  window.__config = {{{configstring}}};
 </script>
 <script src="https://apis.google.com/js/api.js?onload=gapiResolve" async defer></script>
 <script src="/js/gulliver.js" async defer></script>


### PR DESCRIPTION
Slightly cleaner, I think--we gain a global but avoid having to embed client ids into JS. There will probably be other values we need to make accessible to the front-end too. 