### PR TITLE
Precache first page visited

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -2,16 +2,26 @@
 
 importScripts('/sw-toolbox/sw-toolbox.js'); /* global toolbox */
 
-// The offline page itself *and* its dependencies
+// URL to return in place of the "offline dino" when client is
+// offline and requests a URL that's not in the cache.
+const OFFLINE_URL = '/.shell/offline';
+
 const OFFLINE = [
-  '/.shell/offline',
+  OFFLINE_URL,
   '/sw.js',
   '/js/gulliver.js'
 ];
 
-const OFFLINE_URL = '/.shell/offline';
-
 toolbox.precache(OFFLINE);
+
+// Cache the page registering the service worker. Without this, the
+// "first" page the user visits is only cached on the second visit,
+// since the first load is uncontrolled.
+toolbox.precache(
+  clients.matchAll({includeUncontrolled: true}).then(l => {
+    return l.map(c => c.url);
+  })
+);
 
 toolbox.options.debug = true;
 toolbox.router.default = (request, values, options) => {


### PR DESCRIPTION
Fixes #116, which can be reproduced via:

1. Clear cache, service workers, etc.
2. Load http://localhost:8080/.
3. Click on a PWA to load a different URL.
4. Go offline.
5. Hit "back" in the browser.

Expected behavior:

http://localhost:8080 appears as in step (2).

Actual behavior:

(Custom) offline page appears.