### PR TITLE
Add lighthouse-score to PWA and details page

### DIFF
--- a/lib/images.js
+++ b/lib/images.js
@@ -59,7 +59,7 @@ function fetchAndSave(url, destFile) {
 function saveImage(response, destFile) {
   return new Promise((resolve, reject) => {
     if (response.status !== 200) {
-      reject(new Error('Bad Response loading image: ' + response.status));
+      reject(new Error('Bad Response (' + response.status + ') loading image: ' + response.url));
     }
 
     const contentType = response.headers.get('Content-Type');

--- a/lib/pwa.js
+++ b/lib/pwa.js
@@ -115,10 +115,11 @@ exports.save = function(pwa) {
       })
       .then(savedPwa => {
         updateIcon(savedPwa, pwa.manifest);
-        return savedPwa;
-      })
-      .then(savedPwa => {
-        lighthouseLib.fetchAndSave(savedPwa.id);
+        lighthouseLib.fetchAndSave(savedPwa.id)
+          .then(lighthouse => {
+            savedPwa.lighthouseScore = lighthouse.lighthouseInfo.totalScore;
+            db.update(ENTITY_NAME, savedPwa.id, savedPwa);
+          });
         return resolve(savedPwa);
       })
       .catch(err => {

--- a/models/lighthouse.js
+++ b/models/lighthouse.js
@@ -15,6 +15,15 @@
 
 'use strict';
 
+/**
+ * Class representing a Lighthouse report for a PWA
+ *
+ * lighthouseInfo is a JSON with:
+ *   lighthouseInfo.name {string}
+ *   lighthouseInfo.description {string}
+ *	 lighthouseInfo.totalScore {number}
+ *	 lighthouseInfo.scores {array}
+ */
 class Lighthouse {
   constructor(pwaId, absoluteStartUrl, lighthouseInfo) {
     this.pwaId = pwaId;

--- a/models/pwa.js
+++ b/models/pwa.js
@@ -22,8 +22,9 @@ class Pwa {
   constructor(manifestUrl, manifest) {
     this.manifestUrl = manifestUrl;
     this.manifest = manifest;
+    this.lighthouseScore = 0;
     this.created = new Date();
-    this.updated = new Date();
+    this.updated = this.created;
     this.visible = true;
   }
 

--- a/views/pwas/view.hbs
+++ b/views/pwas/view.hbs
@@ -40,7 +40,10 @@
           <h3>{{pwa.name}}</h4>
           <p>{{pwa.description}}</p>
           <p>Added {{moment pwa.created}}</p>
-          <p>Updated {{moment pwa.updated}}</p>          
+          <p>Updated {{moment pwa.updated}}</p>
+          {{#if pwa.lighthouseScore}}
+          <p>Lighthouse Score {{pwa.lighthouseScore}}/100</p>
+          {{/if}}
           {{#if pwa.absoluteStartUrl}}
           <h4><a href="{{pwa.absoluteStartUrl}}">Homepage</a></h4>
           {{/if}}


### PR DESCRIPTION
Fixes #119
Adds (only) the lighthouse score to the details page, not the rest of the info #122