### PR TITLE
Show online/offline status in footer

### DIFF
--- a/public/js/gulliver.js
+++ b/public/js/gulliver.js
@@ -186,6 +186,21 @@ function setupOnlineAware() {
       }
     });
   }
+  const l3 = document.querySelectorAll('div.offline-status.gulliver-online-aware');
+  for (const e of l3) {
+    e.innerHTML = 'Offline';
+    e.addEventListener('change', function() {
+      this.style.opacity = 1;
+      this.style.display = 'block';
+      if (JSON.parse(this.dataset.online)) {
+        this.style.transition = 'opacity .5s ease-in-out';
+        this.style.opacity = 0;
+      } else {
+        this.style.transition = 'opacity .5s ease-in-out';
+        this.style.opacity = 1;
+      }
+    });
+  }
 }
 
 /**

--- a/views/includes/css.hbs
+++ b/views/includes/css.hbs
@@ -139,7 +139,7 @@ button[disabled=disabled], button:disabled {
 
 div.pwabox-body a {
   text-decorations:none;
-  color:inherit;  
+  color:inherit;
 }
 
 .form-group {
@@ -163,6 +163,16 @@ div.pwabox-body a {
 }
 .error {
   color: #f07;
+}
+.offline-status {
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  background-color: #dc322f;
+  color: #ffffff;
+  height: 20px;
+  padding: 10px 20px 10px 20px;
+  display: none;
 }
 
 /* Flex List of PWAs */

--- a/views/includes/footer.hbs
+++ b/views/includes/footer.hbs
@@ -10,6 +10,8 @@
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License. --}}
- 
+
 <!-- Start of footer include. -->
 <!-- End of footer include. -->
+
+<div class="offline-status gulliver-online-aware"></div>


### PR DESCRIPTION
This addresses https://github.com/GoogleChrome/gulliver/issues/69#issuecomment-241420992.

Looks like this:

![screen shot 2016-09-13 at 3 30 21 pm](https://cloud.githubusercontent.com/assets/51244/18477849/04d5d0ea-79c7-11e6-8c11-a2e5c60cec4e.png)
![screen shot 2016-09-13 at 3 30 16 pm](https://cloud.githubusercontent.com/assets/51244/18477854/08bfb270-79c7-11e6-9b9e-c8dbc24dab17.png)

(Small CSS transition between states. Tried for a little while to get the offline status to slide up/down but wasn't working … will wait for UX input #129 before trying harder.)

PTAL @juliantoledo.