### PR TITLE
Eliminate ignoreSignedIn

### DIFF
--- a/public/js/gulliver.js
+++ b/public/js/gulliver.js
@@ -117,28 +117,25 @@ function setupSignedinAware() {
     e.addEventListener('change', function() {
       const online = JSON.parse(this.dataset.online);
       const signedin = JSON.parse(this.dataset.signedin);
-
-      if (e.dataset.ignoreSignedIn !== 'true') {
-        switch (e.tagName.toLowerCase()) {
-          case 'button':
-            if (e.id === 'login') {
-              // Login is "reversed" for login button
-              this.disabled = !online || signedin;
-            } else {
-              this.disabled = !online || !signedin;
-            }
-            break;
-          case 'div':
-            if (online && signedin) {
-              this.style.opacity = 1;
-              this.onclick = null;
-            } else {
-              this.style.opacity = 0.5;
-              this.onclick = f => f.preventDefault();
-            }
-            break;
-          default:
-        }
+      switch (e.tagName.toLowerCase()) {
+        case 'button':
+          if (e.id === 'auth-button') {
+            // auth-button state depends only on online state
+            this.disabled = !online;
+          } else {
+            this.disabled = !online || !signedin;
+          }
+          break;
+        case 'div':
+          if (online && signedin) {
+            this.style.opacity = 1;
+            this.onclick = null;
+          } else {
+            this.style.opacity = 0.5;
+            this.onclick = f => f.preventDefault();
+          }
+          break;
+        default:
       }
     });
   }

--- a/views/includes/header.hbs
+++ b/views/includes/header.hbs
@@ -11,17 +11,16 @@
  See the License for the specific language governing permissions and
  limitations under the License. --}}
 
-<!-- Start of header include. --> 
+<!-- Start of header include. -->
 <div class="navbar">
   <div class="navbar-title"><a id="title" href="/">Gulliver</a></div>
   <div class="navbar-subtitle">
     <a id="subtitle" href="/">PWA Directory</a>
   </div>
 
-  <button 
-    id="auth-button" 
+  <button
+    id="auth-button"
     class="button blue gulliver-online-aware gulliver-signedin-aware"
-    data-ignore-signed-in="true"
   >
     <i class="fa fa-sign-in" aria-hidden="true"></i>
     <span id="auth-button-label">


### PR DESCRIPTION
I don't think the ignoreSignedIn attribute is necessary; we can switch on auth-button instead.