### PR TITLE
Improve color parsing to generate contrast color

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "multer": "^1.1.0",
     "nconf": "^0.8.4",
     "node-fetch": "^1.5.3",
+    "parse-color": "^1.0.0",
     "sw-toolbox": "^3.2.1",
     "urijs": "^1.18.1"
   },

--- a/test/views/helpers/index.js
+++ b/test/views/helpers/index.js
@@ -31,6 +31,10 @@ describe('views.helpers', () => {
       assert.equal('black', helpers.contrastColor('#FFFFFF'));
     });
 
+    it('should return "black" when value is "#fff"', () => {
+      assert.equal('black', helpers.contrastColor('#fff'));
+    });
+
     it('should return "white" when value is "#000000"', () => {
       assert.equal('white', helpers.contrastColor('000000'));
       assert.equal('white', helpers.contrastColor('#000000'));

--- a/views/helpers/index.js
+++ b/views/helpers/index.js
@@ -27,7 +27,11 @@ exports.contrastColor = function(hexcolor) {
     hexcolor = '#' + hexcolor;
   }
 
-  const [r, g, b] = parseColor(hexcolor).rgb;
+  const parsedColor = parseColor(hexcolor);
+  const r = parsedColor.rgb[0];
+  const g = parsedColor.rgb[1];
+  const b = parsedColor.rgb[2];
+  
   const yiq = ((r * 299) + (g * 587) + (b * 114)) / 1000;
   return (yiq >= 128) ? 'black' : 'white';
 };

--- a/views/helpers/index.js
+++ b/views/helpers/index.js
@@ -27,10 +27,7 @@ exports.contrastColor = function(hexcolor) {
     hexcolor = '#' + hexcolor;
   }
 
-  const parsedColor = parseColor(hexcolor);
-  const r = parsedColor.rgb[0];
-  const g = parsedColor.rgb[1];
-  const b = parsedColor.rgb[2];
+  const [r, g, b] = parseColor(hexcolor).rgb;
   const yiq = ((r * 299) + (g * 587) + (b * 114)) / 1000;
   return (yiq >= 128) ? 'black' : 'white';
 };

--- a/views/helpers/index.js
+++ b/views/helpers/index.js
@@ -31,7 +31,7 @@ exports.contrastColor = function(hexcolor) {
   const r = parsedColor.rgb[0];
   const g = parsedColor.rgb[1];
   const b = parsedColor.rgb[2];
-  
+
   const yiq = ((r * 299) + (g * 587) + (b * 114)) / 1000;
   return (yiq >= 128) ? 'black' : 'white';
 };

--- a/views/helpers/index.js
+++ b/views/helpers/index.js
@@ -15,18 +15,22 @@
 
 'use strict';
 const moment = require('moment');
+const parseColor = require('parse-color');
 
 exports.contrastColor = function(hexcolor) {
   if (!hexcolor) {
     return 'white';
   }
 
-  if (hexcolor[0] === '#') {
-    hexcolor = hexcolor.substr(1, hexcolor.length);
+  // Assume that a 6 digit string is a color.
+  if (hexcolor.length === 6 && hexcolor[0] !== '#') {
+    hexcolor = '#' + hexcolor;
   }
-  const r = parseInt(hexcolor.substr(0, 2), 16);
-  const g = parseInt(hexcolor.substr(2, 2), 16);
-  const b = parseInt(hexcolor.substr(4, 2), 16);
+
+  const parsedColor = parseColor(hexcolor);
+  const r = parsedColor.rgb[0];
+  const g = parsedColor.rgb[1];
+  const b = parsedColor.rgb[2];
   const yiq = ((r * 299) + (g * 587) + (b * 114)) / 1000;
   return (yiq >= 128) ? 'black' : 'white';
 };


### PR DESCRIPTION
- Added 'parse-color' package.
- Added failing '#fff' color to tests.

Closes #156 