### PR TITLE
Adds cache invalidation when a PWA is added

### DIFF
--- a/lib/data-cache.js
+++ b/lib/data-cache.js
@@ -62,7 +62,20 @@ function set(key, value, timeout) {
   });
 }
 
+function getMulti(keys) {
+  return new Promise((resolve, reject) => {
+    memcached.getMulti(keys, (err, data) => {
+      if (err) {
+        console.error(err);
+        return reject(err);
+      }
+      return resolve(data);
+    });
+  });
+}
+
 module.exports = {
   get: get,
-  set: set
+  set: set,
+  getMulti: getMulti
 };

--- a/lib/pwa.js
+++ b/lib/pwa.js
@@ -40,6 +40,7 @@ const E_MANIFEST_URL_MISSING = exports.E_MANIFEST_URL_MISSING = 3;
 const E_MISING_USER_INFORMATION = exports.E_MISING_USER_INFORMATION = 4;
 const E_NOT_A_PWA = exports.E_NOT_A_PWA = 5;
 const LIST_ENTITY_NAME = 'PWA_LIST';
+const LIST_LAST_UPDATE_KEY = 'PWA_LIST_LAST_UPDATE';
 const CACHE_TIMEOUT = 60;
 
 const SORT_TYPE_MAP = new Map([
@@ -69,7 +70,7 @@ exports.list = function(skip, limit, sort) {
     sort: sortType.name
   });
 
-  return cache.get(cacheKey)
+  return this.getListFromCache(cacheKey)
     .then(result => {
       const pwas = result.pwas.map(pwa => {
         return Object.assign(new Pwa(), pwa);
@@ -92,10 +93,48 @@ exports.list = function(skip, limit, sort) {
             hasMore: result.hasMore
           };
 
-          cache.set(cacheKey, resultPage, CACHE_TIMEOUT);
+          this.addListToCache(cacheKey, resultPage);
           return resultPage;
         });
     });
+};
+
+exports.getListFromCache = function(key) {
+  return new Promise((resolve, reject) => {
+    cache.getMulti([key, LIST_LAST_UPDATE_KEY])
+      .then(data => {
+        if (!data[key]) {
+          return reject('Not Found. Key: ' + key);
+        }
+
+        if (!data[LIST_LAST_UPDATE_KEY]) {
+          return resolve(data[key]);
+        }
+
+        if (data[LIST_LAST_UPDATE_KEY] >= data[key].cacheTimestamp) {
+          return reject('Data Expired: ' + key);
+        }
+
+        resolve(data[key]);
+      })
+      .catch(err => {
+        console.log(err);
+        return reject(err);
+      });
+  });
+};
+
+exports.addListToCache = function(key, value) {
+  value.cacheTimestamp = Date.now();
+  return cache.set(key, value, CACHE_TIMEOUT);
+};
+
+exports.addPwaToCache = function(pwa) {
+  const pwaCacheKey = JSON.stringify({kind: ENTITY_NAME, key: pwa.id});
+  return Promise.all([
+    cache.set(pwaCacheKey, pwa, CACHE_TIMEOUT),
+    cache.set(LIST_LAST_UPDATE_KEY, Date.now(), CACHE_TIMEOUT * 5)
+  ]);
 };
 
 /**
@@ -212,9 +251,13 @@ exports._save = function(pwa) {
       return db.update(ENTITY_NAME, pwa.id, pwa);
     })
     .then(savedPwa => {
+      this.addPwaToCache(savedPwa);
       this.updateIcon(savedPwa, pwa.manifest)
-        .then(savedPwa => {
-          this.updateLighthouseInfo(savedPwa);
+        .then(_ => {
+          this.updateLighthouseInfo(savedPwa)
+            .then(_ => {
+              this.addPwaToCache(savedPwa);
+            });
         });
       return savedPwa;
     });

--- a/lib/pwa.js
+++ b/lib/pwa.js
@@ -99,22 +99,33 @@ exports.list = function(skip, limit, sort) {
     });
 };
 
+/**
+ * Get a PWA page from cache.
+ *
+ * @param key {string} the key for the page
+ * @return Promise.
+ */
 exports.getListFromCache = function(key) {
   return new Promise((resolve, reject) => {
     cache.getMulti([key, LIST_LAST_UPDATE_KEY])
       .then(data => {
+        // Key not found.
         if (!data[key]) {
           return reject('Not Found. Key: ' + key);
         }
 
+        // No last update timestamp on cache. Since last update timeout is larger than the page
+        // timeout, we know that no update happened after page was loaded. Page is up to date.
         if (!data[LIST_LAST_UPDATE_KEY]) {
           return resolve(data[key]);
         }
 
+        // last update timestamp happened after page was added to cache. Page is expired.
         if (data[LIST_LAST_UPDATE_KEY] >= data[key].cacheTimestamp) {
           return reject('Data Expired: ' + key);
         }
 
+        // last update timestamp happened before page was added to cache. Page is up to date.
         resolve(data[key]);
       })
       .catch(err => {
@@ -124,11 +135,26 @@ exports.getListFromCache = function(key) {
   });
 };
 
+/**
+ * Adds a PWA page to the Cache. Adds a cacheTimestamp property
+ * to the value in order to validate it agains last update later.
+ *
+ * @param key {string} the cache key
+ * @param value {object} the value
+ * @return a Promise
+ */
 exports.addListToCache = function(key, value) {
   value.cacheTimestamp = Date.now();
   return cache.set(key, value, CACHE_TIMEOUT);
 };
 
+/**
+ * Adds a single PWA to the Cache. Also updates the last update timestamp
+ * on the cache.
+ *
+ * @param {Pwa} the Pwa to be added to the cache.
+ * @return a Promise.
+ */
 exports.addPwaToCache = function(pwa) {
   const pwaCacheKey = JSON.stringify({kind: ENTITY_NAME, key: pwa.id});
   return Promise.all([

--- a/test/lib/pwa.js
+++ b/test/lib/pwa.js
@@ -113,6 +113,7 @@ describe('lib.pwa', () => {
       simpleMock.mock(libPwa, 'updateLighthouseInfo').resolveWith(pwa);
       simpleMock.mock(libPwa, 'libManifest').returnWith(libManifest);
       simpleMock.mock(libPwa, 'db').returnWith(db);
+      simpleMock.mock(libPwa, 'addPwaToCache');
 
       return libPwa._save(pwa).should.be.fulfilled.then(updatedPwa => {
         assert.equal(libPwa.findByManifestUrl.callCount, 1);
@@ -126,6 +127,7 @@ describe('lib.pwa', () => {
         assert.equal(db.update.callCount, 1);
         assert.equal(libPwa.updateIcon.callCount, 1);
         assert.equal(libPwa.updateLighthouseInfo.callCount, 1);
+        assert.equal(libPwa.addPwaToCache.callCount, 2);
       });
     });
     it('handles E_MANIFEST_ERROR error', () => {


### PR DESCRIPTION
- When a PWA is added / updated, the current  timestamp is added
to the Cache with the key `PWA_LIST_LAST_UPDATE`. This value
has the timeout of 5 times the Pwa List timeout.
- When a pwa list page is added to the Cache, a property
`cacheTimestamp` with the current timestamp is appended to the
object.
- When a page is loaded from the cache, the `PWA_LIST_LAST_UPDATE`
is also loaded.
- If no value is found for that page, the Promise
fails and the value is loaded from the db.
- If a value is found
from the key, but not found for `PWA_LIST_LAST_UPDATE`, the
timestamp has expired and the Pwa can be used, since the expire
time for the timestam is larger than the one for the PWA.
- If a value for the timestamp is found and is larger then the
PWA List cacheTimestamp, it means the value is expired and the
Promise fails.
- If a value for the timestamp is found and is smaller then the
PWA List cacheTimestamp, the PWA is valid and the Promise resolves.