### PR TITLE
Improve cache timeout for images

### DIFF
--- a/lib/images.js
+++ b/lib/images.js
@@ -25,6 +25,7 @@ const storage = gcloud.storage({
 });
 const bucket = storage.bucket(CLOUD_BUCKET);
 const fetch = require('node-fetch');
+const CACHE_CONTROL_EXPIRES = 60 * 60 * 24; // 1 day.
 
 /**
  * Fetches and Saves an Image to GCloud.
@@ -68,7 +69,8 @@ function saveImage(response, destFile) {
 
       const writeStream = file.createWriteStream({
         metadata: {
-          contentType: contentType
+          contentType: contentType,
+          cacheControl: CACHE_CONTROL_EXPIRES
         }
       });
 


### PR DESCRIPTION
- Set the Cache-Control header when uploading the image to gcloud-
storage to expire in 1 day.

Closes #138 