### PR TITLE
Remove percentage sign and add Lighthouse logo to Lighthouse details

### DIFF
--- a/views/includes/lighthouse.hbs
+++ b/views/includes/lighthouse.hbs
@@ -1,7 +1,10 @@
 <div class="detail-general lighthouse-detail">
   <div class="detail-header">
-    <h3>LIGHTHOUSE</h3>
-    <div>{{pwa.lighthouseScore}}%</div>
+    <h3>LIGHTHOUSE</h3>    
+    <div> 
+        <img src="/img/lighthouse.svg" width="18" height="18" title="Lighthouse Score" alt="Lighthouse logo"/>
+        {{pwa.lighthouseScore}}
+    </div>
   </div>
   <div>
     <div>


### PR DESCRIPTION
This PR includes only the change of removing the '%' sign from the lighthouse score and putting the Lighthouse logo next to the score.

Check here: https://medina-gulliver.appspot.com/pwas/5651124426113024