### PR TITLE
Generate gulliver.js (ES5) from gulliver.es6.js (ES6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ npm-debug.log
 .jshintrc
 .idea/
 key.json
+public/js/gulliver.js
+public/js/gulliver.js.map

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "scripts": {
     "start": "node app.js",
+    "prestart": "tsc --allowJs --removeComments --sourceMap --outFile public/js/gulliver.js public/js/gulliver.es6.js",
     "monitor": "nodemon app.js",
     "deploy": "gcloud preview app deploy app.yaml",
     "mocha": "node_modules/.bin/mocha -R test/ -t 60000",
@@ -42,8 +43,8 @@
   "dependencies": {
     "body-parser": "^1.15.2",
     "cheerio": "^0.22.0",
-    "express": "^4.13.4",
     "dompurify": "^0.8.3",
+    "express": "^4.13.4",
     "google-auth-library": "^0.9.8",
     "google-cloud": "^0.39.0",
     "handlebars": "^4.0.5",
@@ -55,9 +56,10 @@
     "multer": "^1.1.0",
     "nconf": "^0.8.4",
     "node-fetch": "^1.5.3",
-    "serve-static": "^1.11.1",
     "parse-color": "^1.0.0",
+    "serve-static": "^1.11.1",
     "sw-toolbox": "^3.2.1",
+    "typescript": "^2.0.3",
     "urijs": "^1.18.1"
   },
   "devDependencies": {

--- a/public/js/gulliver.es6.js
+++ b/public/js/gulliver.es6.js
@@ -1,3 +1,8 @@
+/*
+ * Generate gulliver.js from this file via `npm prestart`. (`npm start` will run
+ * `prestart` automatically.)
+ */
+
 /* eslint-env browser */
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  // https://www.typescriptlang.org/docs/handbook/compiler-options.html
+  "compilerOptions": {
+    "target": "es5"
+  }
+}


### PR DESCRIPTION
Safari 9 can't handle the arrow functions we had in `gulliver.js`. Add a "build" step to generate an ES5 version.

One (unfortunate) implication of this means that when editing `gulliver.es6.js` we need to run `npm prestart` before reloading. (We should improve this later.)

Note that `npm start` runs this automatically, so `npm start` (and deploying to GCP?) should work just fine.