### PR TITLE
Remove 'unsafe-eval' CSP

### DIFF
--- a/middlewares/index.js
+++ b/middlewares/index.js
@@ -25,7 +25,7 @@ router.use((req, res, next) => {
   /* eslint-disable quotes */
   res.setHeader('content-security-policy', [
     `default-src 'self' https://accounts.google.com https://apis.google.com`,
-    `script-src 'self' 'unsafe-eval' https://apis.google.com https://www.google-analytics.com`,
+    `script-src 'self' https://apis.google.com https://www.google-analytics.com`,
     `style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com/ajax/libs/font-awesome/`,
     `font-src 'self' https://cdnjs.cloudflare.com/ajax/libs/font-awesome/`,
     `img-src 'self' https://storage.googleapis.com https://www.google-analytics.com`


### PR DESCRIPTION
This is no longer needed by scripts we depend on.