### PR TITLE
Optimize images serving

### DIFF
--- a/lib/images.js
+++ b/lib/images.js
@@ -17,6 +17,7 @@
 
 const gcloud = require('google-cloud');
 const config = require('../config/config');
+const sharp = require('sharp');
 
 const CLOUD_BUCKET = config.get('CLOUD_BUCKET');
 
@@ -38,7 +39,17 @@ function fetchAndSave(url, destFile) {
   return new Promise((resolve, reject) => {
     fetch(url)
       .then(response => {
-        return saveImage(response, destFile);
+        if (response.status !== 200) {
+          reject(
+            new Error('Bad Response (' + response.status + ') loading image: ' + response.url));
+        }
+        const contentType = response.headers.get('Content-Type');
+
+        return Promise.all([
+          saveImage(response.body, destFile, contentType),
+          saveImage(response.body, destFile, contentType, 128),
+          saveImage(response.body, destFile, contentType, 64)
+        ]);
       })
       .then(url => {
         resolve(url);
@@ -57,15 +68,11 @@ function fetchAndSave(url, destFile) {
  * @param {string} destFile name of the destination file
  * @return {Promise<string>} full public URL of saved image
  */
-function saveImage(response, destFile) {
+function saveImage(readStream, destFile, contentType, size) {
+  const destFilename = (size || 'original') + '_' + destFile;
   return new Promise((resolve, reject) => {
-    if (response.status !== 200) {
-      reject(new Error('Bad Response (' + response.status + ') loading image: ' + response.url));
-    }
-
-    const contentType = response.headers.get('Content-Type');
     try {
-      const file = bucket.file(destFile);
+      const file = bucket.file(destFilename);
 
       const writeStream = file.createWriteStream({
         metadata: {
@@ -79,10 +86,15 @@ function saveImage(response, destFile) {
       });
 
       writeStream.on('finish', () => {
-        resolve(getPublicUrl(destFile));
+        resolve(getPublicUrl(destFilename));
       });
 
-      response.body.pipe(writeStream);
+      if (size && contentType !== 'image/svg+xml') {
+        const transformer = sharp().resize(size);
+        readStream.pipe(transformer).pipe(writeStream);
+      } else {
+        readStream.pipe(writeStream);
+      }
     } catch (e) {
       reject(e);
     }

--- a/lib/pwa.js
+++ b/lib/pwa.js
@@ -337,7 +337,9 @@ exports.updateIcon = function(pwa, manifest) {
 
     libImages.fetchAndSave(bestIconUrl, bucketFileName)
       .then(savedUrl => {
-        pwa.iconUrl = savedUrl;
+        pwa.iconUrl = savedUrl[0];
+        pwa.iconUrl128 = savedUrl[1];
+        pwa.iconUrl64 = savedUrl[2];
         let updatedPwa = db.update(ENTITY_NAME, pwa.id, pwa);
         console.log('Updated PWA Image: ', pwa.id);
         resolve(updatedPwa);

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "node-fetch": "^1.5.3",
     "parse-color": "^1.0.0",
     "serve-static": "^1.11.1",
+    "sharp": "^0.16.0",
     "sw-offline-google-analytics": "^1.1.1",
     "sw-toolbox": "^3.2.1",
     "typescript": "^2.0.3",

--- a/test/lib/pwa.js
+++ b/test/lib/pwa.js
@@ -64,7 +64,7 @@ describe('lib.pwa', () => {
     });
     it('sets iconUrl', () => {
       // Mock libImages and bd to avoid making real calls
-      simpleMock.mock(libImages, 'fetchAndSave').resolveWith(manifest.getBestIconUrl());
+      simpleMock.mock(libImages, 'fetchAndSave').resolveWith(['original', '128', '64']);
       simpleMock.mock(db, 'update').returnWith(pwa);
       simpleMock.mock(libPwa, 'libImages').returnWith(libImages);
       simpleMock.mock(libPwa, 'db').returnWith(db);
@@ -75,8 +75,9 @@ describe('lib.pwa', () => {
           'https://s1.trrsf.com/fe/zaz-morph/_img/launcher-icon.png?v2');
         assert.equal(libImages.fetchAndSave.lastCall.args[1], '123456789.png');
         assert.equal(db.update.callCount, 1);
-        assert.equal(updatedPwa.iconUrl,
-          'https://s1.trrsf.com/fe/zaz-morph/_img/launcher-icon.png?v2');
+        assert.equal(updatedPwa.iconUrl, 'original');
+        assert.equal(updatedPwa.iconUrl128, '128');
+        assert.equal(updatedPwa.iconUrl64, '64');
       });
     });
   });

--- a/views/includes/pwadetails.hbs
+++ b/views/includes/pwadetails.hbs
@@ -4,9 +4,9 @@
     <div class="pwadetail-header">             
       <div class="pwadetail-logo">
       <a href="{{pwa.absoluteStartUrl}}" target="_blank">
-        {{#if pwa.iconUrl}}
+        {{#if pwa.iconUrl128}}
         <div style="background-color: {{pwa.backgroundColor}}">
-          <img src="{{pwa.iconUrl}}" width="128" height="128"/>
+          <img src="{{pwa.iconUrl128}}" width="128" height="128"/>
         </div>
         {{else}}
         <svg width="128" height="128">

--- a/views/pwas/list.hbs
+++ b/views/pwas/list.hbs
@@ -40,8 +40,8 @@
           <a href="/pwas/{{id}}" style="color:{{contrastColor backgroundColor}}">
             <div class="pwabox-body">
               <div class="pwabox-left">
-                {{#if iconUrl}}
-                  <img src="{{iconUrl}}" width="64" height="64" alt="logo for {{name}}"/>
+                {{#if iconUrl64}}
+                  <img src="{{iconUrl64}}" width="64" height="64" alt="logo for {{name}}"/>
                 {{else}}
                 <svg width="64" height="64">
                   <rect width="64" height="64" stroke-width="4" fill="{{backgroundColor}}" />


### PR DESCRIPTION
- Use the 'sharp' library to create images with 64 and 128 sizes
- Updated tests

Resolves #145 