### PR TITLE
Improve JS build process

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,1 @@
+{ "presets": ["es2015-rollup"] }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "start": "node app.js",
-    "prestart": "tsc --allowJs --removeComments --sourceMap --outFile public/js/gulliver.js public/js/gulliver.es6.js",
+    "prestart": "rollup -c",
     "monitor": "nodemon app.js",
     "deploy": "npm run prestart && gcloud app deploy app.yaml",
     "mocha": "node_modules/.bin/mocha -R test/ -t 60000",
@@ -60,18 +60,21 @@
     "sharp": "^0.16.0",
     "sw-offline-google-analytics": "^1.1.1",
     "sw-toolbox": "^3.2.1",
-    "typescript": "^2.0.3",
     "urijs": "^1.18.1"
   },
   "devDependencies": {
+    "babel-preset-es2015-rollup": "^1.2.0",
     "chai": "^3.0.0",
     "chai-as-promised": "^6.0.0",
     "eslint": "^3.0.1",
     "eslint-config-google": "^0.6.0",
-    "supertest": "^2.0.0",
     "istanbul": "^0.4.4",
     "mocha": "^3.0.1",
-    "simple-mock": "^0.7.0"
+    "rollup": "^0.36.3",
+    "rollup-plugin-babel": "^2.6.1",
+    "rollup-plugin-uglify": "^1.0.1",
+    "simple-mock": "^0.7.0",
+    "supertest": "^2.0.0"
   },
   "engines": {
     "node": ">=0.12.7"

--- a/public/js/gapi.es6.js
+++ b/public/js/gapi.es6.js
@@ -1,0 +1,73 @@
+/* eslint-env browser */
+
+/**
+ * Returns a Promise that fulfills to `window.gapi`. Note that this function
+ * will probably create the global properties `gapiReady` and `gapiResolve`.
+ *
+ * @param {typeof window} context
+ * @param {typeof document} doc
+ * @return {Promise<typeof window.gapi>}
+ */
+export function gapi(context = window, doc = document) {
+  return context.gapiReady || new Promise(resolve => {
+    // Adapted from GA embed code
+    const c = 'gapiResolve';
+    const s = doc.createElement('script');
+    const p = doc.getElementsByTagName('script')[0];
+    s.async = 1;
+    s.src = `https://apis.google.com/js/api.js?onload=${c}`;
+    p.parentNode.insertBefore(s, p);
+    context[c] = () => resolve(window.gapi);
+  });
+}
+
+/**
+ * @template T
+ * @param {string} name the library to load
+ * @return {Promise<T>} resolves to window.gapi[name]
+ */
+export function gapiLoad(name) {
+  return gapi().then(g => {
+    return new Promise(resolve => {
+      g.load(name, () => resolve(g[name]));
+    });
+  });
+}
+
+/**
+ * Promise'd version of [`gapi.client.load`](https://developers.google.com/api-client-library/javascript/reference/referencedocs#gapiclientloadname--------version--------callback).
+ *
+ * @template T
+ * @param {string} name the API client to load
+ * @param {string} [version="v1"] version
+ * @return {Promise<T>} resolves to gapi.client[name]
+ */
+export function clientLoad(name, version) {
+  version = version ? version : 'v1';
+  return gapiLoad('client').then(client => {
+    return new Promise(resolve => {
+      client.load(name, version, () => resolve(client[name]));
+    });
+  });
+}
+
+/**
+ * Promise'd version of [`gapi.auth2.init`](https://developers.google.com/identity/sign-in/web/reference#gapiauth2initparams).
+ *
+ * @param {any} params https://developers.google.com/identity/sign-in/web/reference#gapiauth2initparams
+ * @return {Promise<gapi.auth2.GoogleAuth>} Promise resolving to an initialized gapi.auth2.GoogleAuth object
+ */
+export function authInit(params) {
+  return gapiLoad('auth2').then(auth2 => {
+    /* Ideally we'd just return `auth2.init(params)` here, but
+     * instead we need to work around a few bugs and surprises in
+     * `auth2.init()` and the "Promise" it returns.
+     */
+    return new Promise(resolve => {
+      auth2.init(params).then(t => {
+        t.then = null;
+        resolve(t);
+      });
+    });
+  });
+}

--- a/public/js/gulliver.es6.js
+++ b/public/js/gulliver.es6.js
@@ -5,77 +5,7 @@
 
 /* eslint-env browser */
 
-/**
- * The `gapiReady` global resolves to window.gapi.
- */
-window.gapiReady = window.gapiReady || new Promise(resolve => {
-  // Adapted from GA embed code
-  const c = 'gapiResolve';
-  const s = document.createElement('script');
-  const p = document.getElementsByTagName('script')[0];
-  s.async = 1;
-  s.src = `https://apis.google.com/js/api.js?onload=${c}`;
-  p.parentNode.insertBefore(s, p);
-  window[c] = () => resolve(window.gapi);
-});
-
-/**
- * Note: window.gapiReady must be a promise that resolves to
- * window.gapi.
- *
- * @template T
- * @param {string} name the library to load
- * @return {Promise<T>} resolves to window.gapi[name]
- */
-function gapiLoad(name) {
-  return new Promise((resolve, reject) => {
-    if ('gapiReady' in window) {
-      window.gapiReady.then(gapi => {
-        gapi.load(name, () => resolve(gapi[name]));
-      });
-    } else {
-      reject('Promise window.gapiReady not found');
-    }
-  });
-}
-
-/**
- * Promise'd version of [`gapi.client.load`](https://developers.google.com/api-client-library/javascript/reference/referencedocs#gapiclientloadname--------version--------callback).
- *
- * @template T
- * @param {string} name the API client to load
- * @param {string} [version="v1"] version
- * @return {Promise<T>} resolves to gapi.client[name]
- */
-function clientLoad(name, version) { // eslint-disable-line no-unused-vars
-  version = version ? version : 'v1';
-  return gapiLoad('client').then(client => {
-    return new Promise(resolve => {
-      client.load(name, version, () => resolve(client[name]));
-    });
-  });
-}
-
-/**
- * Promise'd version of [`gapi.auth2.init`](https://developers.google.com/identity/sign-in/web/reference#gapiauth2initparams).
- *
- * @param {any} params https://developers.google.com/identity/sign-in/web/reference#gapiauth2initparams
- * @return {Promise<gapi.auth2.GoogleAuth>} Promise resolving to an initialized gapi.auth2.GoogleAuth object
- */
-function authInit(params) {
-  return gapiLoad('auth2').then(auth2 => {
-    /* Ideally we'd just return `auth2.init(params)` here, but
-     * instead we need to work around a few bugs and surprises in
-     * `auth2.init()` and the "Promise" it returns.
-     */
-    return new Promise(resolve => {
-      auth2.init(params).then(t => {
-        t.then = null;
-        resolve(t);
-      });
-    });
-  });
-}
+import {authInit} from './gapi.es6.js';
 
 /**
  * Translate generic "system" event like 'online', 'offline' and 'userchange'

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,17 @@
+import babel from 'rollup-plugin-babel';
+import uglify from 'rollup-plugin-uglify';
+
+export default {
+  entry: './public/js/gulliver.es6.js',
+  plugins: [
+    babel(),
+    uglify()
+  ],
+  targets: [
+    {
+      dest: './public/js/gulliver.js',
+      format: 'iife',
+      sourceMap: true
+    }
+  ]
+};


### PR DESCRIPTION
- Split out the gapi-related functions into a separate file
- Use rollup to remove unused code
- Babel instead of TypeScript to transpile JS
- Minify JS via uglify

Related to #89.