### PR TITLE
Track offline and homescreen traffic on Analytics

### DIFF
--- a/public/js/gulliver.es6.js
+++ b/public/js/gulliver.es6.js
@@ -279,5 +279,6 @@ window.dispatchEvent(new CustomEvent(navigator.onLine ? 'online' : 'offline'));
 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 ga('create', window.__config.ga_id, 'auto');
+ga('set', 'dimension1', navigator.onLine);
 ga('send', 'pageview');
 /* eslint-enable */

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
 	"name": "PWA Directory",
 	"short_name": "PwaDir",
 	"description": "A Directory of PWAs",
-	"start_url": "/",
+	"start_url": "/?utm_source=homescreen",
 	"icons": [
 		{
 			"src": "\/favicons\/android-chrome-192x192.png",


### PR DESCRIPTION
- Adds `?utm-source` to  start_url on manifest, which will allow to identify clicks coming from the home-screen.
- Adds custom-dimension to GA that adds `navigator.onLine` as to pageview tracking.