### PR TITLE
Ensure start_url is cached and updated

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -55,6 +55,14 @@ toolbox.router.head(/^/, request => {
   return onlyIfCached(request.url);
 });
 
+toolbox.router.get('/', (request, values, options) => {
+  // Replace requests to start_url with the lastest version of the root page.
+  if (request.url.endsWith('/?utm_source=homescreen')) {
+    request = new Request('/');
+  }
+  return toolbox.router.default(request, values, options);
+});
+
 toolbox.router.default = (request, values, options) => {
   return toolbox.networkFirst(request, values, options)
     .catch(_ => {


### PR DESCRIPTION
Updated sw.js to catch requests to start_url
(`/?utm_source=homescreen`) and respond with the root page (`/`).
This ensures that whenever the root page is updated, the latest
cached page will be served when launched from the homescreen.