### PR TITLE
Adds tracking to Add to Homescreen events

### DIFF
--- a/public/js/gulliver.es6.js
+++ b/public/js/gulliver.es6.js
@@ -281,4 +281,11 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 ga('create', window.__config.ga_id, 'auto');
 ga('set', 'dimension1', navigator.onLine);
 ga('send', 'pageview');
+
+// Setup a listener to track Add to Homescreen events.
+window.addEventListener('beforeinstallprompt', e => {
+  e.userChoice.then(choiceResult => {
+    ga('send', 'event', 'A2H', choiceResult.outcome);      
+  });
+});
 /* eslint-enable */


### PR DESCRIPTION
- Based on informationhere: https://developers.google.com/web/updates/2015/03/increasing-engagement-with-app-install-banners-in-chrome-for-android
- Deployed on https://gulliver-1371.appspot.com/
- Enable chrome://flags/#bypass-app-banner-engagement-checks to debug A2H prompts.