### PR TITLE
Only keep entity counts for PWAs

### DIFF
--- a/lib/model-datastore.js
+++ b/lib/model-datastore.js
@@ -244,6 +244,44 @@ function updateCount(transaction, kind, inc) {
  * @return {Promise<Object>}
  */
 function update(kind, id, data) {
+  return new Promise((resolve, reject) => {
+    let key;
+    if (id) {
+      key = ds.key([kind, parseKey(id)]);
+    } else {
+      key = ds.key(kind);
+    }
+
+    const entity = {
+      key: key,
+      data: toDatastore(data, ['description'])
+    };
+
+    ds.save(
+      entity,
+      err => {
+        data.id = entity.key.id;
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(data);
+      }
+    );
+  });
+}
+
+/**
+ * Creates a new Entity or updates an existing Entity with new data. The provided
+ * data is automatically translated into Datastore format. The Entity will be
+ * queued for background processing.
+ *
+ * @param {string} kind
+ * @param {string} id
+ * @param {Object} data
+ * @return {Promise<Object>}
+ */
+function updateWithCounts(kind, id, data) {
   let key;
   if (id) {
     key = ds.key([kind, parseKey(id)]);
@@ -326,7 +364,7 @@ function read(kind, id) {
  * @param {string} id
  * @return {Promise<>}
  */
-function _delete(kind, id) {
+function _deleteWithCounts(kind, id) {
   const key = ds.key([kind, parseKey(id)]);
   const transaction = ds.transaction();
   return startTransaction(transaction)
@@ -351,6 +389,25 @@ function _delete(kind, id) {
     });
 }
 
+/**
+ * Deletes an Object with the specified kind and Id from the Datastore
+ *
+ * @param {string} kind
+ * @param {string} id
+ * @return {Promise<>}
+ */
+function _delete(kind, id) {
+  return new Promise((resolve, reject) => {
+    const key = ds.key([kind, parseKey(id)]);
+    ds.delete(key, err => {
+      if (err) {
+        return reject(err);
+      }
+      resolve();
+    });
+  });
+}
+
 module.exports = {
   create: (kind, data) => {
     update(kind, null, data);
@@ -359,5 +416,7 @@ module.exports = {
   read: read,
   update: update,
   delete: _delete,
+  updateWithCounts: updateWithCounts,
+  deleteWithCounts: _deleteWithCounts,
   list: list
 };

--- a/lib/pwa.js
+++ b/lib/pwa.js
@@ -274,7 +274,7 @@ exports._save = function(pwa) {
     })
     .then(description => {
       pwa.metaDescription = description;
-      return db.update(ENTITY_NAME, pwa.id, pwa);
+      return db.updateWithCounts(ENTITY_NAME, pwa.id, pwa);
     })
     .then(savedPwa => {
       this.addPwaToCache(savedPwa);
@@ -344,7 +344,7 @@ exports.updateIcon = function(pwa, manifest) {
         pwa.iconUrl = savedUrl[0];
         pwa.iconUrl128 = savedUrl[1];
         pwa.iconUrl64 = savedUrl[2];
-        let updatedPwa = db.update(ENTITY_NAME, pwa.id, pwa);
+        let updatedPwa = db.updateWithCounts(ENTITY_NAME, pwa.id, pwa);
         console.log('Updated PWA Image: ', pwa.id);
         resolve(updatedPwa);
       })
@@ -366,7 +366,7 @@ exports.updateLighthouseInfo = function(pwa) {
     libLighthouse.fetchAndSave(pwa.id)
     .then(lighthouse => {
       pwa.lighthouseScore = lighthouse.lighthouseInfo.totalScore;
-      let updatedPwa = db.update(ENTITY_NAME, pwa.id, pwa);
+      let updatedPwa = db.updateWithCounts(ENTITY_NAME, pwa.id, pwa);
       console.log('Updated PWA Lighthouse info for: ', pwa.id);
       resolve(updatedPwa);
     })

--- a/test/lib/model-datastore.js
+++ b/test/lib/model-datastore.js
@@ -93,7 +93,7 @@ describe('lib.model-datastore', () => {
     });
 
     it('counts objects correctly', () => {
-      return db.update(ENTITY_NAME, null, DB_OBJECT)
+      return db.updateWithCounts(ENTITY_NAME, null, DB_OBJECT)
         .then(() => {
           return db.count(ENTITY_NAME)
             .then(result => {

--- a/test/lib/pwa.js
+++ b/test/lib/pwa.js
@@ -65,7 +65,7 @@ describe('lib.pwa', () => {
     it('sets iconUrl', () => {
       // Mock libImages and bd to avoid making real calls
       simpleMock.mock(libImages, 'fetchAndSave').resolveWith(['original', '128', '64']);
-      simpleMock.mock(db, 'update').returnWith(pwa);
+      simpleMock.mock(db, 'updateWithCounts').returnWith(pwa);
       simpleMock.mock(libPwa, 'libImages').returnWith(libImages);
       simpleMock.mock(libPwa, 'db').returnWith(db);
 
@@ -74,7 +74,7 @@ describe('lib.pwa', () => {
         assert.equal(libImages.fetchAndSave.lastCall.args[0],
           'https://s1.trrsf.com/fe/zaz-morph/_img/launcher-icon.png?v2');
         assert.equal(libImages.fetchAndSave.lastCall.args[1], '123456789.png');
-        assert.equal(db.update.callCount, 1);
+        assert.equal(db.updateWithCounts.callCount, 1);
         assert.equal(updatedPwa.iconUrl, 'original');
         assert.equal(updatedPwa.iconUrl128, '128');
         assert.equal(updatedPwa.iconUrl64, '64');
@@ -89,13 +89,13 @@ describe('lib.pwa', () => {
     it('sets lighthouseScore', () => {
       // Mock libLighthouse and bd to avoid making real calls
       simpleMock.mock(libLighthouse, 'fetchAndSave').resolveWith(lighthouse);
-      simpleMock.mock(db, 'update').returnWith(pwa);
+      simpleMock.mock(db, 'updateWithCounts').returnWith(pwa);
       simpleMock.mock(libPwa, 'libLighthouse').returnWith(libLighthouse);
       simpleMock.mock(libPwa, 'db').returnWith(db);
       return libPwa.updateLighthouseInfo(pwa).should.be.fulfilled.then(updatedPwa => {
         assert.equal(libLighthouse.fetchAndSave.callCount, 1);
         assert.equal(libLighthouse.fetchAndSave.lastCall.args[0], '123456789');
-        assert.equal(db.update.callCount, 1);
+        assert.equal(db.updateWithCounts.callCount, 1);
         assert.equal(updatedPwa.lighthouseScore, 83);
       });
     });
@@ -166,7 +166,7 @@ describe('lib.pwa', () => {
       simpleMock.mock(libPwa, 'findByManifestUrl').resolveWith(pwa);
       simpleMock.mock(libManifest, 'fetchManifest').resolveWith(manifest);
       simpleMock.mock(libPwa, 'fetchMetadataDescription').resolveWith('test-description');
-      simpleMock.mock(db, 'update').returnWith(pwa);
+      simpleMock.mock(db, 'updateWithCounts').returnWith(pwa);
       simpleMock.mock(libPwa, 'updateIcon').resolveWith(pwa);
       simpleMock.mock(libPwa, 'updateLighthouseInfo').resolveWith(pwa);
       simpleMock.mock(libPwa, 'libManifest').returnWith(libManifest);
@@ -182,7 +182,7 @@ describe('lib.pwa', () => {
         assert.equal(libPwa.fetchMetadataDescription.callCount, 1);
         assert.equal(libPwa.fetchMetadataDescription.lastCall.args[0], pwa);
         assert.equal(updatedPwa.metaDescription, 'test-description');
-        assert.equal(db.update.callCount, 1);
+        assert.equal(db.updateWithCounts.callCount, 1);
         assert.equal(libPwa.updateIcon.callCount, 1);
         assert.equal(libPwa.updateLighthouseInfo.callCount, 1);
         assert.equal(libPwa.addPwaToCache.callCount, 2);


### PR DESCRIPTION
- Updating counts need a transaction and can lead to database
contention when entitities are added / removed too frequently.

- Createad new methods 'updateWithCounts' and 'deleteWithCounts'
to be used for entities that want to keep track of counts.

- This design is temporary, and model-datastore should be
refactored to become a class that can be extended to override
functionality. eg: a pwa-datastore could override the update /
delete methods to keep track of counts.