### PR TITLE
Reorganize api controllers

### DIFF
--- a/controllers/api/index.js
+++ b/controllers/api/index.js
@@ -16,7 +16,7 @@
 'use strict';
 
 const express = require('express');
-const router = express.Router(); // eslint-disable-line
+const router = express.Router(); // eslint-disable-line new-cap
 
 // Includes APIs for Lighthouse (/api/lighthouse)
 router.use('/lighthouse', require('./lighthouse'));

--- a/controllers/api/index.js
+++ b/controllers/api/index.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2015-2016, Google, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const express = require('express');
+const router = express.Router(); // eslint-disable-line
+
+// Includes APIs for Lighthouse (/api/lighthouse)
+router.use('/lighthouse', require('./lighthouse'));
+
+module.exports = router;

--- a/controllers/api/lighthouse.js
+++ b/controllers/api/lighthouse.js
@@ -16,7 +16,7 @@
 'use strict';
 
 const express = require('express');
-const lighthouseLib = require('../lib/lighthouse');
+const lighthouseLib = require('../../lib/lighthouse');
 const router = express.Router(); // eslint-disable-line new-cap
 const CACHE_CONTROL_EXPIRES = 60 * 60 * 24; // 1 day.
 
@@ -27,7 +27,7 @@ const CACHE_CONTROL_EXPIRES = 60 * 60 * 24; // 1 day.
  * it uses the Google Charts JSON format:
  *  https://developers.google.com/chart/interactive/docs/reference#dataparam
  */
-router.get('/lighthouse-graph/:pwaId', (req, res) => {
+router.get('/graph/:pwaId', (req, res) => {
   res.setHeader('Content-Type', 'application/json');
 
   lighthouseLib.getLighthouseGraphByPwaId(req.params.pwaId)

--- a/public/js/lighthouse-chart.js
+++ b/public/js/lighthouse-chart.js
@@ -5,7 +5,7 @@
  * Use to make the API request to get the Lighthouse chart data for a PWA.
  */
 const CHART_ELEMENT_ID = 'chart';
-const CHART_BASE_URL = '/api/lighthouse-graph/';
+const CHART_BASE_URL = '/api/lighthouse/graph/';
 
 function drawChart() {
   const chartDiv = document.getElementById(CHART_ELEMENT_ID);

--- a/test/controllers/api.js
+++ b/test/controllers/api.js
@@ -44,7 +44,7 @@ describe('controllers.api', () => {
       simpleMock.mock(lighthouseLib, 'getLighthouseGraphByPwaId').resolveWith('mocked graph data');
       // /api/ is part of the router, we need to start from /lighthouse-graph/
       request(app)
-        .get('/lighthouse-graph/1234567')
+        .get('/lighthouse/graph/1234567')
         .expect('Content-Type', /json/)
         .expect(200).should.be.fulfilled.then(res => {
           assert.equal(res.body, 'mocked graph data');
@@ -58,7 +58,7 @@ describe('controllers.api', () => {
       simpleMock.mock(lighthouseLib, 'getLighthouseGraphByPwaId').resolveWith(null);
       // /api/ is part of the router, we need to start from /lighthouse-graph/
       request(app)
-        .get('/lighthouse-graph/123')
+        .get('/lighthouse/graph/123')
         .expect('Content-Type', /json/)
         .expect(400).should.be.rejected.then(res => {
           assert.equal(res.body, undefined);


### PR DESCRIPTION
Created an '/controllers/api' folder to make it easier to add more
API's without putting all off them inside api.js. This is necessary
for the upcoming addition of the notification subscription API.