### PR TITLE
Refactor Toolbar

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -20,7 +20,7 @@ html {
 *:after {
   box-sizing: inherit;
   /* don't show Chrome's default blue tap highlight */
-  -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 
 body {
@@ -54,6 +54,7 @@ a:hover {
   text-decoration: underline; 
 }
 main {
+  padding-top: 16px;
   padding-right: 8px;
   padding-left: 8px;
   padding-bottom: 44px;
@@ -142,39 +143,32 @@ main {
           flex-direction: row;
   font-weight: 500;
   color: white;
-  background: #2196F3;
-  padding-left: 16px;
-  margin-bottom: 16px;
+  font-size: 16px;
   line-height: 48px;
-  height: 48px;
+  font-weight: 400;
+  background: #2196F3;
+  padding: 0;
   box-shadow: 0 2px 2px 0 rgba(0,0,0,.14),0 3px 1px -2px rgba(0,0,0,.2),0 1px 5px 0 rgba(0,0,0,.12);
+}
+.section-title #subtitle {
+  margin: 0 16px;
 }
 .section-title .back {
   font-size: 24px;
-  padding-right: 16px;
-  height: 54px;
-  line-height: 54px;
-  width: 48px;
+
+  padding: 0 16px;
+}
+.section-title .tab:active,
+.section-title .back:active {
+  background-color: #90CAF9;
 }
 .section-title .tab {
   height: 48px;
   line-height: 54px;
   margin: 0;
   padding: 0 40px 0 40px;
-  color: white;
   opacity: 0.7;
-}
-.tab:hover {
-  border-bottom-style: solid;
-  background: #42A5F5;
-  border-color: #FF8A65;
-  border-width: 2dp;
-  opacity: 1;
-}
-@media (max-width: 410px) {
-  .section-title .tab {
-    padding: 0 16px 0 16px;
-  }
+  font-weight: 500;
 }
 .section-title .activetab {
   color: white;
@@ -185,6 +179,29 @@ main {
 .section-title a, .section-title a:visited {
   color: white;
   text-decoration: none;
+}
+.section-title.tab:hover {
+  border-bottom-style: solid;
+  background: #42A5F5;
+  border-color: #FF8A65;
+  border-width: 2dp;
+  opacity: 1;
+}
+@media (min-width: 600px) {
+  .section-title .tab:first-child {
+    margin-left: auto;
+  }
+  .section-title .tab:last-child {
+    margin-right: auto;
+  }
+  .section-title #subtitle {
+    margin: 0 auto;
+  }
+}
+@media (max-width: 410px) {
+  .section-title .tab {
+    padding: 0 16px;
+  }
 }
 #auth-button {
   position: absolute;

--- a/views/pwas/form.hbs
+++ b/views/pwas/form.hbs
@@ -18,12 +18,10 @@
   </head>
   <body>
     {{> header}}
-
-    {{#if pwa.manifestUrl}}
-    <div class="section-title">Edit a PWA</div>
-    {{else}}
-    <div class="section-title">Submit a PWA</div>
-    {{/if}}
+    <div class="section-title">
+      <a href="/" class="back"><i class="fa fa-chevron-left" aria-hidden="true"></i></a>
+      <div id="subtitle">{{#if pwa.manifestUrl}} Edit a PWA {{else}} Submit a PWA {{/if}}</div>
+    </div>
 
     <main>
       <form id="pwaForm" method="POST">

--- a/views/pwas/form.hbs
+++ b/views/pwas/form.hbs
@@ -20,7 +20,7 @@
     {{> header}}
     <div class="section-title">
       <a href="/" class="back"><i class="fa fa-chevron-left" aria-hidden="true"></i></a>
-      <div id="subtitle">{{#if pwa.manifestUrl}} Edit a PWA {{else}} Submit a PWA {{/if}}</div>
+      <div id="subtitle">Submit a PWA</div>
     </div>
 
     <main>

--- a/views/pwas/list.hbs
+++ b/views/pwas/list.hbs
@@ -20,8 +20,8 @@
     {{> header}}
 
     <div class="section-title">
-      <a href="/?sort=newest"><div class="tab {{#if showNewest}}activetab{{/if}}">New</div></a>
-      <a href="/?sort=score"><div class="tab {{#if showScore}}activetab{{/if}}">Score</div></a>
+      <a class="tab {{#if showNewest}}activetab{{/if}}" href="/?sort=newest">New</a>
+      <a class="tab {{#if showScore}}activetab{{/if}}" href="/?sort=score">Score</a>
     </div>
     <main>
       <div class="toolbar">

--- a/views/pwas/view.hbs
+++ b/views/pwas/view.hbs
@@ -19,7 +19,7 @@
   <body>
     {{> header}}    
     <div class="section-title">
-      <a href="{{backlink}}"><div class="back"><i class="fa fa-chevron-left" aria-hidden="true"></i></div></a>
+      <a href="{{backlink}}" class="back"><i class="fa fa-chevron-left" aria-hidden="true"></i></a>
     </div>
     <main>
       {{> pwadetails pwa=pwa}}


### PR DESCRIPTION
* Center touch target for back button (no left padding)
* Start tabs without margin (see [1])
* Center tabs on desktop -> better discoverability
* Give container padding-top instead of toolbar a padding-bottom -> this
makes it possible to give the container a background color.
* remove unneeded divs

[1] https://material.google.com/components/tabs.html#tabs-usage