### PR TITLE
Preparing rollup to use firebase-notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "parse-color": "^1.0.0",
     "rollup": "^0.36.3",
     "rollup-plugin-babel": "^2.6.1",
+    "rollup-plugin-commonjs": "^5.0.5",
+    "rollup-plugin-node-resolve": "^2.0.0",
     "rollup-plugin-uglify": "^1.0.1",
     "serve-static": "^1.11.1",
     "sharp": "^0.16.0",

--- a/public/js/gulliver.es6.js
+++ b/public/js/gulliver.es6.js
@@ -5,9 +5,11 @@
 
 /* eslint-env browser */
 
-// As used by https://github.com/Financial-Times/polyfill-service/blob/master/polyfills/Promise/config.json
+// A Promise polyfill, as used by
+// https://github.com/Financial-Times/polyfill-service/blob/master/polyfills/Promise/config.json
 import 'yaku/dist/yaku.browser.global.min.js';
-// As used by https://github.com/Financial-Times/polyfill-service/blob/master/polyfills/fetch/config.json
+// A fetch polyfill, as used by
+// https://github.com/Financial-Times/polyfill-service/blob/master/polyfills/fetch/config.json
 import 'whatwg-fetch/fetch';
 
 import {authInit} from './gapi.es6.js';

--- a/public/js/gulliver.es6.js
+++ b/public/js/gulliver.es6.js
@@ -6,9 +6,9 @@
 /* eslint-env browser */
 
 // As used by https://github.com/Financial-Times/polyfill-service/blob/master/polyfills/Promise/config.json
-import '../../node_modules/yaku/dist/yaku.browser.global.min.js';
+import 'yaku/dist/yaku.browser.global.min.js';
 // As used by https://github.com/Financial-Times/polyfill-service/blob/master/polyfills/fetch/config.json
-import '../../node_modules/whatwg-fetch/fetch.js';
+import 'whatwg-fetch/fetch';
 
 import {authInit} from './gapi.es6.js';
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,11 +1,15 @@
 import babel from 'rollup-plugin-babel';
 import uglify from 'rollup-plugin-uglify';
+import nodeResolve from 'rollup-plugin-node-resolve';
+import commonsjs from 'rollup-plugin-commonjs';
 
 export default {
   entry: './public/js/gulliver.es6.js',
   plugins: [
     babel(),
-    uglify()
+    uglify(),
+    nodeResolve(),
+    commonsjs()
   ],
   // Quiet warning: https://github.com/rollup/rollup/wiki/Troubleshooting#this-is-undefined
   context: 'window',


### PR DESCRIPTION
- Added `rollup-plugin-node-resolve` to improve package resolution
- Added `rollup-plugin-commonjs` to make rollup compatible with
commonjs module.export style (used by firebase)