### PR TITLE
refactor pwa detail view

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -43,7 +43,6 @@ h3 {
   font-weight: 400;
   letter-spacing: -.018em;
   text-overflow: ellipsis;
-  line-height: 38px;
 }
 
 a { 
@@ -285,17 +284,18 @@ a.card:hover {
   letter-spacing: .005em;
 }
 
-.card-pwa .pwa-score {
-  font-weight: 600;
-  line-height: 18px;
+.card-pwa .score {
   align-self: flex-end;
   margin-left: auto;
-  background-image: -webkit-image-set(
+  line-height: 18px;
+}
+.score {
+  font-weight: 600;
+  background: no-repeat center left -webkit-image-set(
     url(/img/lighthouse-18.png) 1x,
     url(/img/lighthouse-36.png) 2x
   );
-  background-repeat: no-repeat;
-  padding-left: 22px;
+  padding-left: 24px;
 }
 
 .detail-general {
@@ -318,6 +318,18 @@ a.card:hover {
   background: white;
   border-radius: 2px;
 }
+.detail-general .dates {
+  font-style: italic;
+  margin-top: 16px;
+  font-size: 12px;
+  text-align: center;  
+}
+.detail-general h3 { 
+  margin: 0 0 16px 0;
+}
+.detail-general h3 > .score {
+  float: right;
+}
 .detail-header {
   display: -webkit-box;
   display: -ms-flexbox;
@@ -329,30 +341,35 @@ a.card:hover {
   -webkit-box-pack: justify;
       -ms-flex-pack: justify;
           justify-content: space-between;
-  margin-bottom: 8px;  
+  margin-bottom: 8px;
 }
 .detail-header > * {
   font-size: 24px;
   margin: 0;
   padding: 0;
-}  
-.pwadetail-header {
-  -webkit-display: flex;
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: flex; 
-  -webkit-box-orient: vertical; 
-  -webkit-box-direction: normal; 
-      -ms-flex-direction: column; 
-          flex-direction: column;
-  -webkit-box-align: center;
-      -ms-flex-align: center;
-          align-items: center;
-  margin-bottom: 8px;
 }
-.detail-description {
-  line-height: 1.5em;
+#pwa {
+  display: flex; 
+  flex-direction: column;
+  align-items: center;
+  transition: all 0.3s cubic-bezier(.25,.8,.25,1);
+}
+#pwa:hover {
+  text-decoration: none;
+  box-shadow: 0 14px 28px rgba(0,0,0,0.25), 0 10px 10px rgba(0,0,0,0.22);
+}
+#pwa:active {
+  opacity: 0.5;
+  box-shadow: 0 2px 2px 0 rgba(0,0,0,.14),0 3px 1px -2px rgba(0,0,0,.2),0 1px 5px 0 rgba(0,0,0,.12);
+}
+#pwa code {
   text-align: center;
+  text-decoration: underline;
+  margin-top: 24px;
+}
+#pwa > div,
+#pwa > h3 {
+  margin-top: 16px;
 }
 /* Manifest detail box */
 .manifest-detail {
@@ -380,24 +397,25 @@ a.card:hover {
 }
 #chart {
   width: 100%;
-  min-height: 260px;
+  min-height: 244px;
   padding: 0;
+  margin-bottom: 16px;
+  border-style: solid;
+  border-width: 1px;
+  border-color: #ccc;
+  position: relative;
 }
 #chart_AnnotationChart_borderDiv {
   height: 242px !important;
-  border-color: black;
+  border-style: none;
+  animation: 0.25s ease-in fadeIn;
+  animation-fill-mode: forwards;
 }
 .pwadetail-logo {
  display:block;
 }
 .pwadetail .name {
   font-weight: 600;
-}
-.detail-general .dates {
-  font-style: italic;
-  margin-top: 16px;
-  font-size: 12px;
-  text-align: center;  
 }
 .form-group {
   display: -webkit-box;
@@ -643,3 +661,77 @@ tr:nth-child(odd) {
   text-align: end;
   padding-right: 5px;
 }
+
+.fadeIn {
+  animation: 0.25s ease-in fadeIn;
+  animation-fill-mode: forwards;
+}
+
+@keyframes fadeIn {
+  0% { opacity: 0 }
+  100% { opacity: 1 }
+}
+
+.fadeOut {
+  animation: 0.25s ease-out fadeOut;
+  animation-fill-mode: forwards;
+}
+
+@keyframes fadeOut {
+  0% { opacity: 1 }
+  100% { opacity: 0 }
+}
+
+/* Loader */
+.loader {
+  position: absolute;
+  text-align: center;
+  display: block;
+  height: 10px;
+  top: 50%;
+  left: 50%;
+  transform: translateX(-50%) translateY(-50%);
+  transform-origin: 50% 50%;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.loader-dot {
+  position: relative;
+  display: inline-block;
+
+  height: 10px;
+  width: 10px;
+  margin: 2px;
+  border-radius: 100%;
+  background-color: rgba(0, 0, 0, .3);
+
+  box-shadow: 2px 2px 2px 1px rgba(0, 0, 0, .2);
+  will-change: transform;
+  animation: loader-dots 2s infinite;
+}
+
+.loader .loader-dot:nth-child(1) {
+  animation-delay: 0s;
+}
+
+.loader .loader-dot:nth-child(2) {
+  animation-delay: .1s;
+}
+
+.loader .loader-dot:nth-child(3) {
+  animation-delay: .2s;
+}
+
+@keyframes loader-dots {
+  0%, 100% {
+    transform: scale(.7);
+    background-color: rgba(0, 0, 0, .2);
+  }
+
+  50% {
+    transform: scale(.8);
+    background-color: rgba(0, 0, 0, .5);
+  }
+}
+

--- a/public/js/gapi.es6.js
+++ b/public/js/gapi.es6.js
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2015-2016, Google, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /* eslint-env browser */
 
 /**

--- a/public/js/gulliver.es6.js
+++ b/public/js/gulliver.es6.js
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2015-2016, Google, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Generate gulliver.js from this file via `npm prestart`. (`npm start` will run
  * `prestart` automatically.)
@@ -11,6 +26,7 @@ import '../../node_modules/yaku/dist/yaku.browser.global.min.js';
 import '../../node_modules/whatwg-fetch/fetch.js';
 
 import {authInit} from './gapi.es6.js';
+import './loader.js';
 
 /**
  * Translate generic "system" event like 'online', 'offline' and 'userchange'

--- a/public/js/lighthouse-chart.js
+++ b/public/js/lighthouse-chart.js
@@ -1,24 +1,51 @@
+/**
+ * copyright 2015-2016, google, inc.
+ * licensed under the apache license, version 2.0 (the "license");
+ * you may not use this file except in compliance with the license.
+ * you may obtain a copy of the license at
+ *
+ *    http://www.apache.org/licenses/license-2.0
+ *
+ * unless required by applicable law or agreed to in writing, software
+ * distributed under the license is distributed on an "as is" basis,
+ * without warranties or conditions of any kind, either express or implied.
+ * see the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+
 /* global google */
 /* eslint-env browser */
 
 /**
  * Use to make the API request to get the Lighthouse chart data for a PWA.
  */
-const CHART_ELEMENT_ID = 'chart';
 const CHART_BASE_URL = '/api/lighthouse/graph/';
 
-function drawChart() {
-  const pagewith = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
-  const chartDiv = document.getElementById(CHART_ELEMENT_ID);
-  const pwaId = chartDiv.getAttribute('pwa');
-  if (pwaId) {
+class LighthouseChart {
+
+  constructor() {
+    this.chartElement = document.getElementById('chart');
+    this.loader = new window.Loader(this.chartElement);
+  }
+
+  load() {
+    this.loader.show();
+    google.charts.load('current', {packages: ['annotationchart']});
+    google.charts.setOnLoadCallback(this.drawChart.bind(this));
+  }
+
+  drawChart() {
+    const pwaId = this.chartElement.getAttribute('pwa');
+    if (!pwaId) {
+      return;
+    }
+    const pagewith = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
     fetch(CHART_BASE_URL + pwaId)
       .then(response => response.json())
       .then(jsonData => {
         // Create our data table out of JSON data loaded from server.
         const data = new google.visualization.DataTable(jsonData);
-        const chart = new google.visualization.AnnotationChart(
-          document.getElementById(CHART_ELEMENT_ID));
+        const chart = new google.visualization.AnnotationChart(this.chartElement);
         const options = {
           height: 242,
           displayAnnotations: false,
@@ -30,14 +57,13 @@ function drawChart() {
           max: 100
         };
         chart.draw(data, options);
+        this.loader.hide();
       })
       .catch(err => {
         console.error('There was an error drawing the chart!', err);
       });
   }
+
 }
 
-if (document.getElementById(CHART_ELEMENT_ID)) {
-  google.charts.load('current', {packages: ['annotationchart']});
-  google.charts.setOnLoadCallback(drawChart);
-}
+new LighthouseChart().load();

--- a/public/js/loader.js
+++ b/public/js/loader.js
@@ -1,0 +1,66 @@
+/**
+ * copyright 2015-2016, google, inc.
+ * licensed under the apache license, version 2.0 (the "license");
+ * you may not use this file except in compliance with the license.
+ * you may obtain a copy of the license at
+ *
+ *    http://www.apache.org/licenses/license-2.0
+ *
+ * unless required by applicable law or agreed to in writing, software
+ * distributed under the license is distributed on an "as is" basis,
+ * without warranties or conditions of any kind, either express or implied.
+ * see the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+
+/* eslint-env browser */
+
+/**
+ * A CSS only loader showing three dots.
+ */
+class Loader {
+
+  /**
+   * Create a new loader.
+   *
+   * @param container {HTMLElement} the element containing the loader.
+   */
+  constructor(container) {
+    this.container = container;
+  }
+
+  /**
+   * addLoader adds a CSS loader to the given element.
+   *
+   * @param container {HTMLElement} the element containing the loader.
+   */
+  show() {
+    const loader = document.createElement('div');
+    loader.style['align-items'] = 'center';
+    loader.classList.add('loader');
+    for (let i = 0; i < 3; i++) {
+      const dot = document.createElement('div');
+      dot.classList.add('loader-dot');
+      loader.appendChild(dot);
+    }
+    this.container.appendChild(loader);
+  }
+
+  /**
+   * removeLoader removes a CSS loader from the given element.
+   *
+   * @param container {HTMLElement} the element containing the loader.
+   */
+  hide() {
+    const loaders = this.container.getElementsByClassName('loader');
+    for (let loader of loaders) {
+      loader.classList.add('fadeOut');
+      setTimeout(() => loader.remove(), 500);
+    }
+  }
+}
+
+// HACK: attach loader class to window object so that chart.js (which is not
+// managed by rollup) can use the loader.
+window.Loader = Loader;
+export default Loader;

--- a/views/includes/head.hbs
+++ b/views/includes/head.hbs
@@ -36,9 +36,7 @@
 <script id="config" type="application/json">
 {{{configstring}}}
 </script>
-<script src="/js/gulliver.js" async defer></script>
-<script type="text/javascript" src="https://www.gstatic.com/charts/loader.js" defer></script>
-<script type="text/javascript" src="/js/lighthouse-chart.js" defer></script>
+<script src="/js/gulliver.js" defer></script>
 
 {{> metadata}}
 

--- a/views/includes/lighthouse.hbs
+++ b/views/includes/lighthouse.hbs
@@ -1,15 +1,5 @@
-<div class="detail-general lighthouse-detail">
-  <div class="detail-header">
-    <h3>LIGHTHOUSE</h3>    
-    <div class="lighthouse-score"> 
-        <img src="/img/lighthouse-18.png"  srcset="/img/lighthouse-18.png 1x, /img/lighthouse-36.png 2x" title="Lighthouse Score" alt="Lighthouse logo"/>
-        {{#if pwa.lighthouseScore}}
-          {{pwa.lighthouseScore}}
-        {{else}}
-          <i class="fa fa-hourglass-half" aria-hidden="true" title="Lighthouse in progress"></i>
-        {{/if}}
-    </div>
-  </div>
+<section class="detail-general lighthouse-detail">
+  <h3>LIGHTHOUSE  {{> score pwa}} </h3>    
   {{#if pwa.lighthouseScore}}
   <div id="chart" pwa={{pwa.id}}></div>
   <div>
@@ -47,4 +37,4 @@
     </div>
   </div>
   {{/if}}
-</div>
+</section>

--- a/views/includes/pwadetails.hbs
+++ b/views/includes/pwadetails.hbs
@@ -1,26 +1,19 @@
-<div class="detail-general pwadetail"
-     style="background-color: {{pwa.backgroundColor}};
-             color: {{contrastColor pwa.backgroundColor}};">
-    <div class="pwadetail-header">             
-      <div class="pwadetail-logo">
-      <a href="{{pwa.absoluteStartUrl}}" target="_blank">
-        {{#if pwa.iconUrl128}}
-        <div style="background-color: {{pwa.backgroundColor}}">
-          <img src="{{pwa.iconUrl128}}" width="128" height="128"/>
-        </div>
-        {{else}}
-        <svg width="128" height="128">
-          <rect width="100%" height="100%" stroke-width="4" fill="{{pwa.backgroundColor}}" />
-          <text x="50%" y="50%" fill="{{contrastColor pwa.backgroundColor}}" alignment-baseline="middle" text-anchor="middle" font-size="128px">{{firstLetter pwa.name}}</text>
-        </svg>
-        {{/if}}
-        </a>
-      </div>
-      <h3><a href="{{pwa.absoluteStartUrl}}" style="color: {{contrastColor pwa.backgroundColor}}" target="_blank">{{pwa.name}}</a></h3>
-      <div class="detail-description"><a href="{{pwa.absoluteStartUrl}}" style="color: {{contrastColor pwa.backgroundColor}}" target="_blank">{{pwa.absoluteStartUrl}}</a></div>
-    </div>
-    {{#if pwa.description}}
-      <div class="detail-description">{{pwa.description}}</div>
+<a href="{{pwa.absoluteStartUrl}}"  id="pwa" class="detail-general" style="background-color: {{pwa.backgroundColor}}; color: {{contrastColor pwa.backgroundColor}};">
+
+  <div id="pwa-logo-container" style="background-color: {{pwa.backgroundColor}}">
+    {{#if pwa.iconUrl128}}
+      <img src="{{pwa.iconUrl128}}" width="128" height="128"/>
+    {{else}}
+    <svg class="fadeIn" width="128" height="128">
+      <rect width="100%" height="100%" stroke-width="4" fill="{{pwa.backgroundColor}}" />
+      <text x="50%" y="50%" fill="{{contrastColor pwa.backgroundColor}}" alignment-baseline="middle" text-anchor="middle" font-size="128px">{{firstLetter pwa.name}}</text>
+    </svg>
     {{/if}}
-    <div class="dates">Added {{moment pwa.created}}, Updated {{moment pwa.updated}}</div>
-</div>
+  </div>
+  <h3 id="pwa-name">{{pwa.name}}</h3>
+  <code>{{pwa.absoluteStartUrl}}</code>
+  {{#if pwa.description}}
+    <div id="pwa-description">{{pwa.description}}</div>
+  {{/if}}
+  <div class="dates">Added {{moment pwa.created}}, Updated {{moment pwa.updated}}</div>
+</a>

--- a/views/includes/score.hbs
+++ b/views/includes/score.hbs
@@ -1,0 +1,7 @@
+<span class="score">
+{{#if lighthouseScore}}
+{{lighthouseScore}}
+{{else}}
+<i class="fa fa-hourglass-half" aria-hidden="true" title="Lighthouse in progress"></i>
+{{/if}}
+</span>

--- a/views/pwas/list.hbs
+++ b/views/pwas/list.hbs
@@ -42,13 +42,7 @@
               </svg>
             {{/if}}
             <div class="pwa-name">{{name}}</div>
-            <div class="pwa-score">
-            {{#if lighthouseScore}}
-              {{lighthouseScore}}
-            {{else}}
-              <i class="fa fa-hourglass-half" aria-hidden="true" title="Lighthouse in progress"></i>
-            {{/if}}
-            </div>
+            {{> score }}
           </a>
         {{/each}}
       </div>

--- a/views/pwas/view.hbs
+++ b/views/pwas/view.hbs
@@ -36,5 +36,7 @@
       {{/if}}
     </main>
     {{> footer}}
+    <script src="https://www.gstatic.com/charts/loader.js" defer></script>
+    <script src="/js/lighthouse-chart.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
PWA details card:

* remove unneeded divs
* make the whole card a link (instead of declaring three different
links)
* add card hover effect (WDYT?)
* add card touch effect
* small design changes (more consistent font sizes)

Lighthouse card:

* extract score into separate partial template
* fade in chart
* reserve chart space with border
* show spinner while chart is loading