### PR TITLE
Don't duplicate content for newest

### DIFF
--- a/views/pwas/list.hbs
+++ b/views/pwas/list.hbs
@@ -20,7 +20,7 @@
     {{> header}}
 
     <div class="section-title">
-      <a id="newest" class="tab {{#if showNewest}}activetab{{/if}}" href="/?sort=newest">New</a>
+      <a id="newest" class="tab {{#if showNewest}}activetab{{/if}}" href="/">New</a>
       <a id="score" class="tab {{#if showScore}}activetab{{/if}}" href="/?sort=score">Score</a>
     </div>
     <main>


### PR DESCRIPTION
Currently we show the list of new PWAs for two URLs:

* '/'
* '/?sort=newest'

This means, both pages need to be cached + are potentially duplicated in SERPs. 