### PR TITLE
Log Firebase notification HTTP errors

### DIFF
--- a/lib/data-fetcher.js
+++ b/lib/data-fetcher.js
@@ -157,8 +157,16 @@ function _handleFirebaseResponse(response) {
 
 function firebaseFetch(url, payload) {
   const options = _firebaseOptions(payload);
-  return fetch(url, options)
-    .then(_handleFirebaseResponse);
+  const res = fetch(url, options);
+  res.then(r => {
+    if (r.status !== 200) {
+      r.text().then(msg => {
+        // Add codebase-wide logging system
+        console.warn(`firebaseFetch error: GET ${url} => ${r.status}: ${msg}`);
+      });
+    }
+  });
+  return res.then(_handleFirebaseResponse);
 }
 
 module.exports = {


### PR DESCRIPTION
HTTP level errors get swallowed by the notification abstraction layer.