### PR TITLE
Fix js files being served as text/html

### DIFF
--- a/app.js
+++ b/app.js
@@ -78,6 +78,14 @@ function setCustomCacheControl(res, path) {
   }
 }
 
+// Make node_modules/{{module}} available at /{{module}}
+['sw-toolbox', 'sw-offline-google-analytics'].forEach(module => {
+  app.use(
+   '/' + module,
+   express.static('node_modules/' + module)
+ );
+});
+
 // Middlewares
 app.use(require('./middlewares'));
 

--- a/controllers/index.js
+++ b/controllers/index.js
@@ -39,14 +39,6 @@ router.get('/', (req, res) => {
 // /.shell hosts app shell dependencies
 router.use('/.shell', require('./shell'));
 
-// Make node_modules/sw-toolbox available at /sw-toolbox
-router.use('/sw-toolbox', express.static('node_modules/sw-toolbox'));
-// Make node_modules/sw-offline-google-analytics available at /sw-offline-google-analytics
-router.use(
-  '/sw-offline-google-analytics',
-  express.static('node_modules/sw-offline-google-analytics')
-);
-
 /**
  * This route is used to send config.json to firebase-messaging-sw.js
  */


### PR DESCRIPTION
- Routes in `controllers` are usually text/html. Moved that
  includes those scripts as static to be together with other
  static files configuration
- Fixes #302 