### PR TITLE
Fix browser back with page transitions

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -318,6 +318,9 @@ a.card:hover {
 .detail-general h3 > .score {
   float: right;
 }
+.transition .detail-general {
+  opacity: 0;
+}
 
 /* PWA Overview */
 #pwa {
@@ -326,9 +329,6 @@ a.card:hover {
   flex-direction: column;
   align-items: center;
   transition: all 0.3s cubic-bezier(.25,.8,.25,1);
-}
-.transition #pwa {
-  opacity: 0;
 }
 #pwa:hover {
   text-decoration: none;

--- a/public/js/pwas-view-transition.js
+++ b/public/js/pwas-view-transition.js
@@ -44,7 +44,11 @@ function updateColors() {
   const chartElement = document.getElementById('chart');
   new window.Loader(chartElement, 'dark-primary-background').show();
 
-  pwaDetails.classList.add('fadeIn');
+  // fade in cards
+  const cards = document.getElementsByClassName('detail-general');
+  for (let card of cards) {
+    card.classList.add('fadeIn');
+  }
 }
 
 updateColors();

--- a/public/js/sw-page-transition-client.js
+++ b/public/js/sw-page-transition-client.js
@@ -69,11 +69,7 @@ class PageTransitionClient {
       // stay on the loading page
       return;
     }
-    const url = new URL(this.originalUrl);
-    // force loading cached result
-    url.searchParams.append('cache', 1);
-    this.log('reloading ' + url);
-    window.location.href = url.toString();
+    window.location.reload();
   }
 
   /**

--- a/public/sw.js
+++ b/public/sw.js
@@ -12,7 +12,7 @@ toolbox.options.debug = false;
 // Use page transitions
 importScripts('/js/sw-page-transition.js'); /* global transition */
 
-const VERSION = '2';
+const VERSION = '3';
 const PREFIX = 'gulliver';
 const CACHE_NAME = `${PREFIX}-v${VERSION}`;
 


### PR DESCRIPTION
Removes the `cache=1` query parameter which caused the back function to
break. Instead the sw keeps track of currently shown loading pages.

This commit also fades in the lighthouse card (and not only the pwa
detail card).

Fixes #314