### PR TITLE
Cache first strategy for static assets

### DIFF
--- a/controllers/sw.js
+++ b/controllers/sw.js
@@ -17,37 +17,23 @@
 
 const express = require('express');
 const router = express.Router(); // eslint-disable-line new-cap
-const config = require('../config/config');
+const asset = require('../lib/asset-hashing').asset;
 
-// API
-router.use('/api', require('./api'));
+const ASSETS = JSON.stringify([
+  '/img/GitHub-Mark-Light-24px.png',
+  '/img/GitHub-Mark-Light-48px.png',
+  '/img/lighthouse-18.png',
+  '/img/lighthouse-36.png',
+  '/css/style.css',
+  '/js/gulliver.js',
+  '/js/pwas-list-transition.js',
+  '/js/pwas-view-transition.js'
+].map(assetPath => asset.encode(assetPath)));
 
-// Tasks
-router.use('/tasks', require('./tasks'));
+const ASSETS_JS = `const ASSETS = ${ASSETS};`;
 
-// PWAs
-router.use('/pwas', require('./pwa'));
-
-// Transitions
-router.use('/transitions', require('./transition'));
-
-// ServiceWorker
-router.use('/js', require('./sw'));
-
-router.get('/', (req, res) => {
-  req.url = '/pwas';
-  router.handle(req, res);
-});
-
-// /.shell hosts app shell dependencies
-router.use('/.shell', require('./shell'));
-
-/**
- * This route is used to send config.json to firebase-messaging-sw.js
- */
-router.get('/messaging-config.json', (req, res) => {
-  // eslint-disable-next-line camelcase
-  res.json({firebase_msg_sender_id: config.get('FIREBASE_MSG_SENDER_ID')});
+router.get('/sw-assets-precache.js', (req, res) => {
+  res.send(ASSETS_JS);
 });
 
 module.exports = router;

--- a/lib/asset-hashing.js
+++ b/lib/asset-hashing.js
@@ -42,6 +42,9 @@ class AssetChecksum {
   }
 
   encode(assetPath) {
+    if (!assetPath) {
+      return assetPath;
+    }
     let result = this.checksumCache_[assetPath];
     if (result) {
       return result;
@@ -60,15 +63,18 @@ class AssetChecksum {
   }
 
   decode(assetPath) {
+    if (!assetPath) {
+      return assetPath;
+    }
     const segments = assetPath.split('.');
-    if (segments.length === 1) {
+    if (segments.length <= 1) {
       return assetPath;
     }
     const checksumIndex = segments.length - 2;
     if (segments[checksumIndex].length !== CHECKSUM_LENGTH) {
       return assetPath;
     }
-    segments.splice(segments.length - 2, 1);
+    segments.splice(checksumIndex, 1);
     return segments.join('.');
   }
 

--- a/lib/asset-hashing.js
+++ b/lib/asset-hashing.js
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2015-2016, Google, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const revHash = require('rev-hash');
+
+const CHECKSUM_LENGTH = 10;
+
+class ChecksumProvider {
+
+  constructor(root) {
+    this.root_ = root;
+  }
+
+  get(assetPath) {
+    const buffer = fs.readFileSync(path.join(this.root_, assetPath));
+    return revHash(buffer);
+  }
+
+}
+
+class AssetChecksum {
+
+  constructor(checksumProvider) {
+    this.checksumProvider_ = checksumProvider;
+    this.checksumCache_ = {};
+  }
+
+  encode(assetPath) {
+    let result = this.checksumCache_[assetPath];
+    if (result) {
+      return result;
+    }
+    const checksum = this.checksumProvider_.get(assetPath);
+    const index = assetPath.lastIndexOf('.');
+    if (index === -1) {
+      return assetPath;
+    }
+    result = assetPath.substring(0, index) +
+      '.' +
+      checksum +
+      assetPath.substring(index, assetPath.length);
+    this.checksumCache_[assetPath] = result;
+    return result;
+  }
+
+  decode(assetPath) {
+    const segments = assetPath.split('.');
+    if (segments.length === 1) {
+      return assetPath;
+    }
+    const checksumIndex = segments.length - 2;
+    if (segments[checksumIndex].length !== CHECKSUM_LENGTH) {
+      return assetPath;
+    }
+    segments.splice(segments.length - 2, 1);
+    return segments.join('.');
+  }
+
+}
+
+module.exports.asset = new AssetChecksum(new ChecksumProvider('public'));
+
+// Exported for testing
+module.exports.ChecksumProvider = ChecksumProvider;
+module.exports.AssetChecksum = AssetChecksum;
+module.exports.CHECKSUM_LENGTH = CHECKSUM_LENGTH;

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "nconf": "^0.8.4",
     "node-fetch": "^1.5.3",
     "parse-color": "^1.0.0",
+    "rev-hash": "^1.0.0",
     "rollup": "^0.39.2",
     "rollup-plugin-babel": "^2.6.1",
     "rollup-plugin-commonjs": "^7.0.0",

--- a/public/sw.js
+++ b/public/sw.js
@@ -11,6 +11,7 @@ toolbox.options.debug = false;
 
 // Use page transitions
 importScripts('/js/sw-page-transition.js'); /* global transition */
+importScripts('/js/sw-assets-precache.js'); /* global ASSETS */
 
 const VERSION = '3';
 const PREFIX = 'gulliver';
@@ -24,23 +25,17 @@ const OFFLINE_URL = '/.shell/offline';
 const TRANSITION_PWA_LIST = '/transitions/pwas';
 const TRANSITION_PWA_VIEW = '/transitions/pwas/view';
 
-const OFFLINE = [
-  OFFLINE_URL,
-  '/img/GitHub-Mark-Light-24px.png',
-  '/img/GitHub-Mark-Light-48px.png',
-  '/img/lighthouse-18.png',
-  '/img/lighthouse-36.png',
-  '/css/style.css',
-  '/sw.js',
-  '/js/gulliver.js',
-  '/messaging-config.json',
-  '/js/pwas-list-transition.js',
-  '/js/pwas-view-transition.js',
+const TRANSITION_PAGES = [
   TRANSITION_PWA_LIST,
   TRANSITION_PWA_VIEW
 ];
 
-toolbox.precache(OFFLINE);
+const OFFLINE = [
+  OFFLINE_URL,
+  '/messaging-config.json'
+];
+
+toolbox.precache(OFFLINE.concat(ASSETS).concat(TRANSITION_PAGES));
 toolbox.options.cache.name = CACHE_NAME;
 
 // Cache the page registering the service worker. Without this, the
@@ -87,6 +82,10 @@ toolbox.router.get('/', (request, values, options) => {
     request = new Request('/');
   }
   return toolbox.router.default(request, values, options);
+});
+
+toolbox.router.get(/.*\.[js|png|svg|css]/, (request, values, options) => {
+  return toolbox.cacheFirst(request, values, options);
 });
 
 toolbox.router.default = (request, values, options) => {

--- a/test/lib/asset-hashing.js
+++ b/test/lib/asset-hashing.js
@@ -44,6 +44,12 @@ describe('AssetChecksum', () => {
     it('ignores dirs', () => {
       assert.equal(asset.encode('public/style'), 'public/style');
     });
+    it('ignores empty string', () => {
+      assert.equal(asset.encode(''), '');
+    });
+    it('ignores null', () => {
+      assert.equal(asset.encode(null), null);
+    });
     it('caches results', () => {
       asset.encode('public/style.css');
       asset.encode('public/style.css');
@@ -54,6 +60,12 @@ describe('AssetChecksum', () => {
   describe('decode', () => {
     it('ignores dirs', () => {
       assert.equal(asset.decode('public/style'), 'public/style');
+    });
+    it('ignores empty string', () => {
+      assert.equal(asset.decode(''), '');
+    });
+    it('ignores null', () => {
+      assert.equal(asset.decode(null), null);
     });
     it('removes checksum from file name', () => {
       assert.equal(asset.decode('public/style.1234567890.css'), 'public/style.css');

--- a/test/lib/asset-hashing.js
+++ b/test/lib/asset-hashing.js
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2015-2016, Google, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* global describe it beforeEach afterEach*/
+'use strict';
+
+const assert = require('chai').assert;
+const simple = require('simple-mock');
+
+const assetHashing = require('../../lib/asset-hashing');
+
+describe('ChecksumProvider', () => {
+  it('calculates checksum', () => {
+    const checksumProvider = new assetHashing.ChecksumProvider(__dirname);
+    assert.equal(checksumProvider.get('asset-hashing.js').length, assetHashing.CHECKSUM_LENGTH);
+  });
+});
+
+describe('AssetChecksum', () => {
+  let checksumProvider = new assetHashing.ChecksumProvider();
+  let asset;
+
+  beforeEach(() => {
+    simple.mock(checksumProvider, 'get', () => '1234567890');
+    asset = new assetHashing.AssetChecksum(checksumProvider);
+  });
+
+  describe('encode', () => {
+    it('adds checksum to file name', () => {
+      assert.equal(asset.encode('public/style.css'), 'public/style.1234567890.css');
+    });
+    it('ignores dirs', () => {
+      assert.equal(asset.encode('public/style'), 'public/style');
+    });
+    it('caches results', () => {
+      asset.encode('public/style.css');
+      asset.encode('public/style.css');
+      assert.equal(checksumProvider.get.callCount, 1);
+    });
+  });
+
+  describe('decode', () => {
+    it('ignores dirs', () => {
+      assert.equal(asset.decode('public/style'), 'public/style');
+    });
+    it('removes checksum from file name', () => {
+      assert.equal(asset.decode('public/style.1234567890.css'), 'public/style.css');
+    });
+    it('only checksums with length of 10', () => {
+      assert.equal(asset.decode('public/style.123456789.css'), 'public/style.123456789.css');
+    });
+  });
+
+  afterEach(() => {
+    simple.restore();
+  });
+});
+

--- a/views/helpers/index.js
+++ b/views/helpers/index.js
@@ -19,6 +19,7 @@ const DEFAULT_DARK = '#000000';
 
 const moment = require('moment');
 const parseColor = require('parse-color');
+const assetHashing = require('../../lib/asset-hashing').asset;
 
 function contrastColor(hexcolor) {
   if (!hexcolor) {
@@ -112,4 +113,5 @@ exports.registerHelpers = function(hbs) {
   hbs.registerHelper('highlightedJson', exports.highlightedJson);
   hbs.registerHelper('getAggregationTableRow', exports.getAggregationTableRow);
   hbs.registerHelper('getAuditTableRow', exports.getAuditTableRow);
+  hbs.registerHelper('asset', assetPath => assetHashing.encode(assetPath));
 };

--- a/views/includes/head.hbs
+++ b/views/includes/head.hbs
@@ -27,7 +27,7 @@
 <meta name="msapplication-config" content="/favicons/browserconfig.xml">
 <meta name="theme-color" content="#7cc0ff">
 
-<link rel="stylesheet" type="text/css" href="/css/style.css">
+<link rel="stylesheet" type="text/css" href="{{asset '/css/style.css'}}">
 
 <!-- Origin Trial Token, feature = Web Share, origin = https://pwa-directory.appspot.com, expires = 2016-12-06 -->
 <meta http-equiv="origin-trial" data-feature="Web Share" data-expires="2016-12-06" content="AuNW4MmMk4aT1N9HPDpSlUPkBywNReGpXpbTC+9nOE/rv6W6mToe7J1ZSmz35g+6BbPzjmE9gpBTZOrb2aXf6gwAAABgeyJvcmlnaW4iOiAiaHR0cHM6Ly9wd2EtZGlyZWN0b3J5LmFwcHNwb3QuY29tOjQ0MyIsICJmZWF0dXJlIjogIldlYlNoYXJlIiwgImV4cGlyeSI6IDE0ODEwNDQyMDJ9">
@@ -35,9 +35,9 @@
 <script id="config" type="application/json">
 {{{configstring}}}
 </script>
-<script src="/js/gulliver.js" defer></script>
+<script src="{{asset '/js/gulliver.js'}}" defer></script>
 {{#if transition}}
-<script src="/js/sw-page-transition-client.js" defer></script>
+<script src="{{asset '/js/sw-page-transition-client.js'}}" defer></script>
 {{/if}}
 
 {{> metadata}}

--- a/views/pwas/list.hbs
+++ b/views/pwas/list.hbs
@@ -66,7 +66,7 @@
     </main>
     {{> footer}}
     {{#if transition}}
-    <script src="/js/pwas-list-transition.js" defer></script>
+    <script src="{{asset '/js/pwas-list-transition.js'}}" defer></script>
     {{/if}}
   </body>
 </html>

--- a/views/pwas/view.hbs
+++ b/views/pwas/view.hbs
@@ -35,10 +35,10 @@
     </main>
     {{> footer}}
     {{#if transition}}
-    <script src="/js/pwas-view-transition.js" defer></script>
+    <script src="{{asset '/js/pwas-view-transition.js'}}" defer></script>
     {{else}}
     <script src="https://www.gstatic.com/charts/loader.js" defer></script>
-    <script src="/js/lighthouse-chart.js" defer></script>
+    <script src="{{asset '/js/lighthouse-chart.js'}}" defer></script>
     {{/if}}
   </body>
 </html>


### PR DESCRIPTION
Adds a checksum to static assets (public/.*[js,.css]). Fixes #318.

* Ensures that sw caches a consistent state of static assets => this
avoids sw loops on script/sw updates. Fixes #317.
* Static assets have now the maximum cache expiry date.
* SW now uses cache first strategy for js, images & css. Fixes #301.