### PR TITLE
Add preconnect to improve page load speed

### DIFF
--- a/views/includes/head.hbs
+++ b/views/includes/head.hbs
@@ -26,7 +26,8 @@
 <link rel="shortcut icon" href="/favicons/favicon.ico">
 <meta name="msapplication-config" content="/favicons/browserconfig.xml">
 <meta name="theme-color" content="#7cc0ff">
-
+<link rel="preconnect" href="https://storage.googleapis.com">
+<link rel="preconnect" href="https://apis.google.com">
 <link rel="stylesheet" type="text/css" href="{{asset '/css/style.css'}}">
 
 <!-- Origin Trial Token, feature = Web Share, origin = https://pwa-directory.appspot.com, expires = 2016-12-06 -->


### PR DESCRIPTION
Added link rel preconnect to https://storage.googleapis.com to
improve the time it takes for the page to be visually complete.
Also added preconnect to https://apis.google.com to improve the
speed in which the login/logout button state renders.

Those 2 preconnects make the page visually complete 1 second faster on 3G connections.

Before:
<img width="978" alt="screen shot 2017-01-19 at 3 58 17 pm" src="https://cloud.githubusercontent.com/assets/1733592/22114308/ea3f6b70-de60-11e6-9e78-ca4335e44ca5.png">

After:
<img width="954" alt="screen shot 2017-01-19 at 3 57 42 pm" src="https://cloud.githubusercontent.com/assets/1733592/22114312/f061f590-de60-11e6-86d2-45250115dafd.png">


