### PR TITLE
Add Analytics tracking to Push Notification

### DIFF
--- a/lib/pwa.js
+++ b/lib/pwa.js
@@ -414,7 +414,7 @@ exports.sendNewAppNotification = function(pwa) {
     return Promise.resolve(pwa);
   }
   console.log('Sending Notification for ', pwa.id);
-  const clickAction = config.get('CANONICAL_ROOT') + 'pwas/' + pwa.id;
+  const clickAction = config.get('CANONICAL_ROOT') + 'pwas/' + pwa.id + '?utm_source=push';
   return notificationsLib.sendPush('new-apps', {
     title: pwa.name + ' added to PWA Directory',
     body: pwa.description || '',


### PR DESCRIPTION
Adds the `utm_source` query parameter with the value `push`.