### PR TITLE
Temporary fix for form submission

### DIFF
--- a/public/js/gulliver.es6.js
+++ b/public/js/gulliver.es6.js
@@ -104,7 +104,7 @@ class Gulliver {
   }
 }
 
-const gulliver = new Gulliver();
+window.gulliver = new Gulliver();
 
 // Fire 'online' or 'offline' event on page load. (Without this, would only
 // fire on change.)

--- a/public/js/pwa-form.es6.js
+++ b/public/js/pwa-form.es6.js
@@ -16,7 +16,13 @@
 /* eslint-env browser */
 
 class PwaForm {
+  constructor(window) {
+    this.window = window;
+    this.signIn = window.gulliver.signIn;
+  }
+
   setup() {
+    console.log('Setting up PWA Form');
     this.pwaForm = document.querySelector('#pwaForm');
     if (!this.pwaForm) {
       console.log('%c#pwaForm not found.', 'color:red');
@@ -33,18 +39,21 @@ class PwaForm {
       console.log('%c#pwaSubmit not found.', 'color:red');
     }
 
-    this._setupChangeListener();
-    this._setupSaveButton();
+    this._updateFormFields();
+    this._setupListeners();
   }
 
-  _setupChangeListener() {
-    // Setup a listener for user change events.
-    this.pwaForm.addEventListener('change', () => {
-      this.idTokenInput.setAttribute('value', this.pwaForm.dataset.idToken);
-    });
+  _updateFormFields() {
+    this.idTokenInput.setAttribute('value', this.signIn.signedIn ? this.signIn.idToken : '');
   }
 
-  _setupSaveButton() {
+  /**
+   * Sets up a listeners for events.
+   */
+  _setupListeners() {
+    // Setup listener for the userchange event.
+    window.addEventListener('userchange', this._updateFormFields.bind(this));
+
     // Disable the save button after been clicked to avoid double submission.
     this.submitButton.addEventListener('click', _ => {
       this.submitButton.disabled = true;
@@ -53,5 +62,7 @@ class PwaForm {
   }
 }
 
-const pwaForm = new PwaForm();
-pwaForm.setup();
+// TODO: Setting pwaForm to window is a temporary hack to make the Form work after a transition.
+// To be removed before refactoring is finished.
+window.__pwaForm = new PwaForm(window);
+window.__pwaForm.setup();

--- a/public/js/signin.js
+++ b/public/js/signin.js
@@ -48,6 +48,24 @@ export default class SignIn {
     });
   }
 
+  get signedIn() {
+    return this.user && this.user.isSignedIn();
+  }
+
+  get user() {
+    if (!this.auth) {
+      return null;
+    }
+    return this.auth.currentUser.get();
+  }
+
+  get idToken() {
+    if (!this.signedIn) {
+      return null;
+    }
+    return this.user.getAuthResponse().id_token;
+  }
+
   signIn() {
     if (!this.auth) {
       console.log('Auth not ready!');

--- a/public/js/ui/client-transition.js
+++ b/public/js/ui/client-transition.js
@@ -80,6 +80,24 @@ export default class ClientTransition {
         .then(_ => {
           window.history.pushState(window.location.href, 'PWA Directory', url);
           ClientTransition.rewriteOnClicks();
+
+          // TODO: Temporary hack to make the Form work after a transition.
+          // To be replaced with proper dynamic module loading before refactor is finishd
+          const loadPwaFormJs = () => {
+            if (window.__pwaForm) {
+              window.__pwaForm.setup();
+              return;
+            }
+            const script = document.createElement('script');
+            script.type = 'text/javascript';
+            script.defer = true;
+            script.src = '/js/pwa-form.js';
+            document.querySelector('head').appendChild(script);
+          };
+          if (url.includes('/pwas/add')) {
+            loadPwaFormJs();
+          }
+          // End of module loading hack.
         });
     }
   }


### PR DESCRIPTION
When loading the form as a result of a transition, it needs to
dynamically load the pwa-form.js for it to work. I've implemented
a temporary and ugly solution, that needs to be replaced with proper
module loading before merging PRPL to master.