### PR TITLE
Handle clicks to open links in a new tab correctly

### DIFF
--- a/public/js/routing/router.js
+++ b/public/js/routing/router.js
@@ -67,6 +67,10 @@ export default class Router {
   _takeOverAnchorLinks(root) {
     root.querySelectorAll('a').forEach(element => {
       element.addEventListener('click', e => {
+        if (e.button !== 0 || e.ctrlKey || e.metaKey || e.shiftKey || e.altKey) {
+          return true;
+        }
+
         // Link does not have an url.
         if (!e.currentTarget.href) {
           return true;

--- a/public/js/routing/router.js
+++ b/public/js/routing/router.js
@@ -64,10 +64,14 @@ export default class Router {
     this._updateContent();
   }
 
+  _isLeftClickWithoutModifiers(e) {
+    return e.button === 0 && !e.ctrlKey && !e.metaKey && !e.shiftKey && !e.altKey;
+  }
+
   _takeOverAnchorLinks(root) {
     root.querySelectorAll('a').forEach(element => {
       element.addEventListener('click', e => {
-        if (e.button !== 0 || e.ctrlKey || e.metaKey || e.shiftKey || e.altKey) {
+        if (!this._isLeftClickWithoutModifiers(e)) {
           return true;
         }
 

--- a/public/js/routing/router.js
+++ b/public/js/routing/router.js
@@ -64,14 +64,14 @@ export default class Router {
     this._updateContent();
   }
 
-  _isLeftClickWithoutModifiers(e) {
-    return e.button === 0 && !e.ctrlKey && !e.metaKey && !e.shiftKey && !e.altKey;
+  _isNotLeftClickWithoutModifiers(e) {
+    return e.button !== 0 || e.ctrlKey || e.metaKey || e.shiftKey || e.altKey;
   }
 
   _takeOverAnchorLinks(root) {
     root.querySelectorAll('a').forEach(element => {
       element.addEventListener('click', e => {
-        if (!this._isLeftClickWithoutModifiers(e)) {
+        if (this._isNotLeftClickWithoutModifiers(e)) {
           return true;
         }
 


### PR DESCRIPTION
 - Changed router not to intercept anchor clicks when those clicks
   are generated by a button other than the left button, or if
   there's a modified on the button click. This will properly
   handle middle button clicks and Cmd+left clicks that opens
   links in a new tab.