### PR TITLE
Improve variable and method names

### DIFF
--- a/public/js/gulliver.es6.js
+++ b/public/js/gulliver.es6.js
@@ -62,7 +62,7 @@ class Gulliver {
 
   _addRoute(regexp, transitionStrategy, shellState) {
     const route = new Route(regexp, transitionStrategy);
-    this.shell.addState(route, shellState);
+    this.shell.setStateForRoute(route, shellState);
     this.router.addRoute(route);
   }
 

--- a/public/js/routing/router.js
+++ b/public/js/routing/router.js
@@ -33,20 +33,20 @@ export default class Router {
 
   _updateContent() {
     const location = this._window.document.location.href;
-    const page = this.findRoute(location);
-    if (!page) {
+    const route = this.findRoute(location);
+    if (!route) {
       console.error('Url did not match any router: ', location);
       // TODO: navigate to 404?
       return;
     }
 
-    page.transitionOut(this._container);
-    page.retrieveContent(location)
+    route.transitionOut(this._container);
+    route.retrieveContent(location)
       .then(content => {
         this._container.innerHTML = content;
-        this._shell.afterAttach(page);
+        this._shell.updateState(route);
         this._window.scrollTo(0, 0);
-        page.transitionIn(this._container);
+        route.transitionIn(this._container);
         this._takeOverAnchorLinks(this._container);
       })
       .catch(err => {
@@ -86,8 +86,8 @@ export default class Router {
         }
 
         // Check if there's a route for this url.
-        const page = this.findRoute(e.currentTarget.href);
-        if (!page) {
+        const route = this.findRoute(e.currentTarget.href);
+        if (!route) {
           return true;
         }
 

--- a/public/js/routing/router.js
+++ b/public/js/routing/router.js
@@ -44,7 +44,7 @@ export default class Router {
     route.retrieveContent(location)
       .then(content => {
         this._container.innerHTML = content;
-        this._shell.updateState(route);
+        this._shell.onRouteChange(route);
         this._window.scrollTo(0, 0);
         route.transitionIn(this._container);
         this._takeOverAnchorLinks(this._container);

--- a/public/js/shell.js
+++ b/public/js/shell.js
@@ -24,8 +24,8 @@ export default class Shell {
     this._states = new Map();
   }
 
-  addState(page, state) {
-    this._states.set(page, state);
+  addState(route, state) {
+    this._states.set(route, state);
   }
 
   _showElement(element, visible) {
@@ -49,8 +49,8 @@ export default class Shell {
     tab.classList.remove('activetab');
   }
 
-  afterAttach(page) {
-    const options = this._states.get(page);
+  updateState(route) {
+    const options = this._states.get(route);
     this._showElement(this._backlink, options.backlink);
     this._showElement(this._subtitle, options.subtitle);
     this._tabs.forEach(tab => this._updateTab(tab, options));

--- a/public/js/shell.js
+++ b/public/js/shell.js
@@ -24,8 +24,8 @@ export default class Shell {
     this._states = new Map();
   }
 
-  addState(route, state) {
-    this._states.set(route, state);
+  setStateForRoute(route, shellState) {
+    this._states.set(route, shellState);
   }
 
   _showElement(element, visible) {
@@ -49,7 +49,7 @@ export default class Shell {
     tab.classList.remove('activetab');
   }
 
-  updateState(route) {
+  onRouteChange(route) {
     const options = this._states.get(route);
     this._showElement(this._backlink, options.backlink);
     this._showElement(this._subtitle, options.subtitle);


### PR DESCRIPTION
- Rename instances of `page` variables to `route`.
- Rename `afterUpdate` method on Shell to `updateState`.