### PR TITLE
Inlines chart.js and form.js in gulliver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,5 @@ npm-debug.log
 key.json
 public/js/gulliver.js
 public/js/gulliver.js.map
-public/js/lighthouse-chart.js
-public/js/lighthouse-chart.js.map
-public/js/pwa-form.js
-public/js/pwa-form.js.map
 public/firebase-messaging-sw.js
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "start": "node app.js",
-    "prestart": "rollup -c rollup-config/gulliver.js && rollup -c rollup-config/lighthouse-chart.js && rollup -c rollup-config/pwa-form.js && npm run generate-msg-sw",
+    "prestart": "rollup -c rollup-config/gulliver.js && npm run generate-msg-sw",
     "monitor": "nodemon app.js",
     "deploy": "npm run prestart && gcloud app deploy app.yaml",
     "mocha": "_mocha test/**/*",

--- a/public/js/gulliver.es6.js
+++ b/public/js/gulliver.es6.js
@@ -27,7 +27,6 @@ import 'yaku/dist/yaku.browser.global.min.js';
 // https://github.com/Financial-Times/polyfill-service/blob/master/polyfills/fetch/config.json
 import 'whatwg-fetch/fetch';
 
-import './loader.js';
 import Messaging from './messaging';
 import NotificationCheckbox from './ui/notification-checkbox';
 import Config from './gulliver-config';
@@ -39,6 +38,8 @@ import Router from './routing/router';
 import Route from './routing/route';
 import Shell from './shell';
 import FadeInOutTransitionStrategy from './routing/transitions';
+import PwaForm from './pwa-form';
+import LighthouseChart from './lighthouse-chart';
 
 class Gulliver {
   constructor() {
@@ -55,13 +56,18 @@ class Gulliver {
     this.signIn = new SignIn(window, this.config);
     this.signInButton = new SignInButton(this.signIn, document.querySelector('#auth-button'));
 
+    const currentRoute = this.router.findRoute(window.location.href);
+    if (currentRoute) {
+      currentRoute.onAttached();
+    }
+
     // Setup Analytics
     this.analytics = new Analytics(window, this.config);
     this.analytics.trackPageView(window.location.href);
   }
 
-  _addRoute(regexp, transitionStrategy, shellState) {
-    const route = new Route(regexp, transitionStrategy);
+  _addRoute(regexp, transitionStrategy, onRouteAttached, shellState) {
+    const route = new Route(regexp, transitionStrategy, onRouteAttached);
     this.shell.setStateForRoute(route, shellState);
     this.router.addRoute(route);
   }
@@ -69,21 +75,30 @@ class Gulliver {
   _setupRoutes() {
     const fadeInOutTransitionStrategy = new FadeInOutTransitionStrategy();
     // Route for `/pwas/add`.
-    this._addRoute(/\/pwas\/add/, fadeInOutTransitionStrategy, {
+    const setupPwaForm = () => {
+      const pwaForm = new PwaForm(window, this.signIn);
+      pwaForm.setup();
+    };
+
+    this._addRoute(/\/pwas\/add/, fadeInOutTransitionStrategy, setupPwaForm, {
       showTabs: false,
       backlink: true,
       subtitle: true
     });
 
+    const setupLighthouseChart = () => {
+      new LighthouseChart().load();
+    };
+
     // Route for `/pwas/[id]`.
-    this._addRoute(/\/pwas\/(\d+)/, fadeInOutTransitionStrategy, {
+    this._addRoute(/\/pwas\/(\d+)/, fadeInOutTransitionStrategy, setupLighthouseChart, {
       showTabs: false,
       backlink: true,
       subtitle: false
     });
 
     // Route for `/?sort=score`.
-    this._addRoute(/\/\?.*sort=score/, fadeInOutTransitionStrategy, {
+    this._addRoute(/\/\?.*sort=score/, fadeInOutTransitionStrategy, null, {
       showTabs: true,
       backlink: false,
       subtitle: false,
@@ -91,7 +106,7 @@ class Gulliver {
     });
 
     // Route for `/`.
-    this._addRoute(/.+/, fadeInOutTransitionStrategy, {
+    this._addRoute(/.+/, fadeInOutTransitionStrategy, null, {
       showTabs: true,
       backlink: false,
       subtitle: false,

--- a/public/js/gulliver.es6.js
+++ b/public/js/gulliver.es6.js
@@ -97,8 +97,10 @@ class Gulliver {
       subtitle: false
     });
 
+    const nop = () => {};
+
     // Route for `/?sort=score`.
-    this._addRoute(/\/\?.*sort=score/, fadeInOutTransitionStrategy, null, {
+    this._addRoute(/\/\?.*sort=score/, fadeInOutTransitionStrategy, nop, {
       showTabs: true,
       backlink: false,
       subtitle: false,
@@ -106,7 +108,7 @@ class Gulliver {
     });
 
     // Route for `/`.
-    this._addRoute(/.+/, fadeInOutTransitionStrategy, null, {
+    this._addRoute(/.+/, fadeInOutTransitionStrategy, nop, {
       showTabs: true,
       backlink: false,
       subtitle: false,

--- a/public/js/lighthouse-chart.js
+++ b/public/js/lighthouse-chart.js
@@ -22,17 +22,39 @@ import Loader from './loader';
  */
 const CHART_BASE_URL = '/api/lighthouse/graph/';
 
-class LighthouseChart {
+export default class LighthouseChart {
 
   constructor() {
     this.chartElement = document.getElementById('chart');
     this.loader = new Loader(this.chartElement, 'dark-primary-background');
   }
 
+  _loadChartsApi() {
+    if (window.google && window.google.charts) {
+      console.log('Googler Charts Loader already loaded');      
+      return Promise.resolve(window.google);
+    }
+
+    console.log('Loading Googler Charts Loader');
+    return new Promise((resolve, reject) => {
+      const script = document.createElement('script');
+      script.defer = true;
+      script.src = 'https://www.gstatic.com/charts/loader.js';
+      script.onload = () => {
+        console.log(window.google);
+        resolve(window.google);
+      }
+      script.onerror = reject;
+      document.querySelector('head').appendChild(script);
+    });
+  }
   load() {
     this.loader.show();
-    google.charts.load('current', {packages: ['annotationchart']});
-    google.charts.setOnLoadCallback(this.drawChart.bind(this));
+    this._loadChartsApi()
+      .then(google => {
+        google.charts.load('current', {packages: ['annotationchart']});
+        google.charts.setOnLoadCallback(this.drawChart.bind(this));
+      });
   }
 
   drawChart() {
@@ -68,4 +90,3 @@ class LighthouseChart {
       });
   }
 }
-new LighthouseChart().load();

--- a/public/js/lighthouse-chart.js
+++ b/public/js/lighthouse-chart.js
@@ -41,11 +41,10 @@ export default class LighthouseChart {
       script.defer = true;
       script.src = 'https://www.gstatic.com/charts/loader.js';
       script.onload = () => {
-        console.log(window.google);
         resolve(window.google);
       }
       script.onerror = reject;
-      document.querySelector('head').appendChild(script);
+      document.head.appendChild(script);
     });
   }
   load() {

--- a/public/js/pwa-form.js
+++ b/public/js/pwa-form.js
@@ -15,27 +15,27 @@
 
 /* eslint-env browser */
 
-class PwaForm {
-  constructor(window) {
-    this.window = window;
-    this.signIn = window.gulliver.signIn;
+export default class PwaForm {
+  constructor(window, signIn) {
+    this._window = window;
+    this._signIn = signIn;
   }
 
   setup() {
     console.log('Setting up PWA Form');
-    this.pwaForm = document.querySelector('#pwaForm');
-    if (!this.pwaForm) {
+    this._pwaForm = document.querySelector('#pwaForm');
+    if (!this._pwaForm) {
       console.log('%c#pwaForm not found.', 'color:red');
       return;
     }
 
-    this.idTokenInput = this.pwaForm.querySelector('#idToken');
-    if (!this.idTokenInput) {
+    this._idTokenInput = this._pwaForm.querySelector('#idToken');
+    if (!this._idTokenInput) {
       console.log('%c#idToken not found.', 'color:red');
     }
 
-    this.submitButton = this.pwaForm.querySelector('#pwaSubmit');
-    if (!this.idTokenInput) {
+    this._submitButton = this._pwaForm.querySelector('#pwaSubmit');
+    if (!this._idTokenInput) {
       console.log('%c#pwaSubmit not found.', 'color:red');
     }
 
@@ -44,7 +44,7 @@ class PwaForm {
   }
 
   _updateFormFields() {
-    this.idTokenInput.setAttribute('value', this.signIn.signedIn ? this.signIn.idToken : '');
+    this._idTokenInput.setAttribute('value', this._signIn.signedIn ? this._signIn.idToken : '');
   }
 
   /**
@@ -52,17 +52,12 @@ class PwaForm {
    */
   _setupListeners() {
     // Setup listener for the userchange event.
-    window.addEventListener('userchange', this._updateFormFields.bind(this));
+    this._window.addEventListener('userchange', this._updateFormFields.bind(this));
 
     // Disable the save button after been clicked to avoid double submission.
-    this.submitButton.addEventListener('click', _ => {
-      this.submitButton.disabled = true;
-      this.pwaForm.submit();
+    this._submitButton.addEventListener('click', _ => {
+      this._submitButton.disabled = true;
+      this._pwaForm.submit();
     });
   }
 }
-
-// TODO: Setting pwaForm to window is a temporary hack to make the Form work after a transition.
-// To be removed before refactoring is finished.
-window.__pwaForm = new PwaForm(window);
-window.__pwaForm.setup();

--- a/public/js/routing/route.js
+++ b/public/js/routing/route.js
@@ -16,9 +16,10 @@
 /* eslint-env browser */
 
 export default class Route {
-  constructor(matchRegex, transitionStrategy) {
+  constructor(matchRegex, transitionStrategy, onAttached) {
     this._transitionStrategy = transitionStrategy;
     this._matchRegex = matchRegex;
+    this._onAttached = onAttached;
   }
 
   matches(url) {
@@ -37,6 +38,11 @@ export default class Route {
 
   transitionIn(container) {
     this._transitionStrategy.transitionIn(container);
+  }
+
+  onAttached() {
+    console.log('onAttached');
+    return this._onAttached && this._onAttached();
   }
 
   getContentOnlyUrl(url) {

--- a/public/js/routing/router.js
+++ b/public/js/routing/router.js
@@ -48,6 +48,7 @@ export default class Router {
         this._window.scrollTo(0, 0);
         route.transitionIn(this._container);
         this._takeOverAnchorLinks(this._container);
+        route.onAttached();
       })
       .catch(err => {
         console.error('Error getting page content for: ', location, ' Error: ', err);

--- a/views/pwas/form.hbs
+++ b/views/pwas/form.hbs
@@ -16,7 +16,6 @@
 <html lang="en">
   <head>
     {{> head}}
-    <script typ="text/javascript" src="/js/pwa-form.js" defer></script>
   </head>
   <body>
     {{> header}}

--- a/views/pwas/view.hbs
+++ b/views/pwas/view.hbs
@@ -16,8 +16,6 @@
 <html lang="en">
   <head>
     {{> head}}
-    <script src="https://www.gstatic.com/charts/loader.js" defer></script>
-    <script src="{{asset '/js/lighthouse-chart.js'}}" defer></script>
   </head>
   <body>
     {{> header}}


### PR DESCRIPTION
Adds `lighthouse-chart.js` and `pwa-form.js` as static imports to Gulliver so that the chart and the form work properly when being rendered from the client-side.

Adding both scripts to `gulliver.js` makes it grow by only 2.7k.