### PR TITLE
Gzip and set proper cache-control to images

### DIFF
--- a/lib/images.js
+++ b/lib/images.js
@@ -22,6 +22,7 @@ const sharp = require('sharp');
 const stream = require('stream');
 const strongDataUri = require('strong-data-uri');
 const url = require('url');
+const zlib = require('zlib');
 
 const CLOUD_BUCKET = config.get('CLOUD_BUCKET');
 const storage = gcloud.storage({
@@ -112,7 +113,8 @@ function saveImage(readStream, destFile, contentType, size) {
     const writeStream = file.createWriteStream({
       metadata: {
         contentType: contentType,
-        cacheControl: CACHE_CONTROL_EXPIRES
+        contentEncoding: 'gzip',
+        cacheControl: 'public, max-age=' + CACHE_CONTROL_EXPIRES
       }
     });
 
@@ -124,14 +126,15 @@ function saveImage(readStream, destFile, contentType, size) {
       resolve(getPublicUrl(destFilename));
     });
 
+    const gzip = zlib.createGzip();
     if (size && contentType !== 'image/svg+xml') {
       const transformer = sharp().resize(size);
       transformer.on('error', err => {
         reject(err);
       });
-      readStream.pipe(transformer).pipe(writeStream);
+      readStream.pipe(transformer).pipe(gzip).pipe(writeStream);
     } else {
-      readStream.pipe(writeStream);
+      readStream.pipe(gzip).pipe(writeStream);
     }
   });
 }


### PR DESCRIPTION
We had the wrong cache-control header and we can use gzip for the images.