### PR TITLE
Execute more than 1 tasks per cron job run

### DIFF
--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -38,7 +38,7 @@ exports.push = function(task) {
         return resolve(result);
       })
       .catch(err => {
-        console.log(err);
+        console.error(err);
         return reject(E_SAVING_TASK);
       });
   });
@@ -61,7 +61,7 @@ exports.pop = function() {
           .then(_ => {
             return resolve(task);
           }).catch(err => {
-            console.log(err);
+            console.error(err);
             return reject(E_DELETE_TASK_POP);
           });
       })
@@ -71,6 +71,11 @@ exports.pop = function() {
   });
 };
 
+/**
+ * Execute a task
+ *
+ * @return {Promise<Task>}
+ */
 exports.executePwaTask = function(task) {
   return pwaLib.find(task.pwaId)
     .then(pwa => {
@@ -82,7 +87,7 @@ exports.executePwaTask = function(task) {
           return task;
         })
         .catch(err => {
-          console.log('Error running task: ' + err);
+          console.error('Error running task: ' + err);
           task.retries -= 1;
           if (task.retries >= 0) {
             tasksLib.push(task);
@@ -91,6 +96,24 @@ exports.executePwaTask = function(task) {
         });
     })
     .catch(err => {
-      console.log(err);
+      console.error(err);
+    });
+};
+
+/**
+ * Pop the oldest Task and execute it
+ *
+ * @return {Promise<Task | null>}
+ */
+exports.popExecute = function() {
+  return tasksLib.pop()
+    .then(task => {
+      if (task) {
+        return tasksLib.executePwaTask(task)
+          .then(task => {
+            return task;
+          });
+      }
+      return null;
     });
 };

--- a/test/app/controllers/tasks.js
+++ b/test/app/controllers/tasks.js
@@ -60,7 +60,6 @@ describe('controllers.tasks', () => {
     });
 
     it('respond with 200 when X-Appengine-Cron is present', done => {
-      // Mock lib to avoid making real calls
       simpleMock.mock(tasksLib, 'push').resolveWith(null);
       simpleMock.mock(pwaLib, 'list').resolveWith(listPwas);
       request(app)
@@ -86,7 +85,16 @@ describe('controllers.tasks', () => {
     });
 
     it('respond with 200 when X-Appengine-Cron is present', done => {
-      // Mock lib to avoid making real calls
+      simpleMock.mock(tasksLib, 'pop').resolveWith(null);
+      request(app)
+        .get('/execute')
+        .set(APP_ENGINE_CRON, true)
+        .expect(200).should.be.fulfilled.then(_ => {
+          done();
+        });
+    });
+
+    it('Execute 1 task', done => {
       simpleMock.mock(tasksLib, 'pop').resolveWith(task);
       simpleMock.mock(tasksLib, 'executePwaTask').resolveWith(null);
       request(app)
@@ -95,6 +103,21 @@ describe('controllers.tasks', () => {
         .expect(200).should.be.fulfilled.then(_ => {
           assert.equal(tasksLib.pop.callCount, 1);
           assert.equal(tasksLib.executePwaTask.callCount, 1);
+          done();
+        });
+    });
+
+    it('Execute 3 tasks', done => {
+      simpleMock.mock(tasksLib, 'popExecute');
+      simpleMock.mock(tasksLib, 'pop').resolveWith(task);
+      simpleMock.mock(tasksLib, 'executePwaTask').resolveWith(null);
+      request(app)
+        .get('/execute?tasks=3')
+        .set(APP_ENGINE_CRON, true)
+        .expect(200).should.be.fulfilled.then(_ => {
+          assert.equal(tasksLib.popExecute.callCount, 3);
+          assert.equal(tasksLib.pop.callCount, 3);
+          assert.equal(tasksLib.executePwaTask.callCount, 3);
           done();
         });
     });

--- a/test/app/lib/tasks.js
+++ b/test/app/lib/tasks.js
@@ -116,4 +116,28 @@ describe('lib.tasks', () => {
       });
     });
   });
+
+  describe('#popExecute', () => {
+    afterEach(() => {
+      simpleMock.restore();
+    });
+    it('pop and execute a task', () => {
+      simpleMock.mock(libTasks, 'pop').resolveWith(task);
+      simpleMock.mock(libTasks, 'executePwaTask').resolveWith(task);
+      return libTasks.popExecute().should.be.fulfilled.then(savedTask => {
+        assert.equal(savedTask.pwaId, 123456789);
+        assert.equal(libTasks.pop.callCount, 1);
+        assert.equal(libTasks.executePwaTask.callCount, 1);
+      });
+    });
+    it('pop and execute a task (pop is null)', () => {
+      simpleMock.mock(libTasks, 'pop').resolveWith(null);
+      simpleMock.mock(libTasks, 'executePwaTask');
+      return libTasks.popExecute().should.be.fulfilled.then(savedTask => {
+        assert.equal(savedTask, null);
+        assert.equal(libTasks.pop.callCount, 1);
+        assert.equal(libTasks.executePwaTask.callCount, 0);
+      });
+    });
+  });
 });


### PR DESCRIPTION
At the moment we can only execute 1 task per minute (minimum time for cron jobs), however our webperformance server can handle more.