### PR TITLE
Add rel="noopener" to external links

### DIFF
--- a/views/includes/footer.hbs
+++ b/views/includes/footer.hbs
@@ -18,7 +18,7 @@
   <div class="offline-status">Offline</div>
   <ul>
     <li>   
-      <a href="https://github.com/GoogleChrome/gulliver" target="_blank">
+      <a href="https://github.com/GoogleChrome/gulliver" target="_blank" rel="noopener">
         <img id="github-logo" class="github-logo" srcset="/img/GitHub-Mark-Light-24px.png 1x, /img/GitHub-Mark-Light-48px.png 2x" width="24" height="24" alt="Github" attribution="github">
         <span>View on Github</span>
       </a>

--- a/views/includes/pwadetails.hbs
+++ b/views/includes/pwadetails.hbs
@@ -1,4 +1,4 @@
-<a href="{{pwa.absoluteStartUrl}}"  id="pwa" class="detail-general" style="background-color: {{pwa.backgroundColor}}; color: {{contrastColor pwa.backgroundColor}};">
+<a href="{{pwa.absoluteStartUrl}}"  id="pwa" class="detail-general" style="background-color: {{pwa.backgroundColor}}; color: {{contrastColor pwa.backgroundColor}};" target="_blank" rel="noopener">
 
   <div id="pwa-logo-container">
     {{#if pwa.iconUrl128}}

--- a/views/pwas/view.hbs
+++ b/views/pwas/view.hbs
@@ -28,7 +28,7 @@
         {{> pagespeedinsight}}
         {{#if pwa.manifest}}
         <div class="detail-general">
-        <h3><a href="{{pwa.manifestUrl}}" target="_blank">MANIFEST</a></h3>
+        <h3><a href="{{pwa.manifestUrl}}" target="_blank" rel="noopener">MANIFEST</a></h3>
         <pre>{{{highlightedJson rawManifestJson}}}</pre>
         </div>
         {{/if}}


### PR DESCRIPTION
- Add target="_blank" to open PWA's on a new tab.
- Add rel="noopener" to external links that use target="_blank".

Fixes #382 