### PR TITLE
Fixes extra H2 pushes for CSS and JS

### DIFF
--- a/middlewares/index.js
+++ b/middlewares/index.js
@@ -39,7 +39,7 @@ router.use((req, res, next) => {
   res.setHeader('x-xss-protection', '1; mode=block');
 
   // Set the preload header if a full render is being requested.
-  if (!req.query.contentOnly) {
+  if (!req.query.contentOnly && !req.originalUrl.startsWith('/.app/')) {
     res.setHeader('Link',
       `<${CSSPATH}>; rel=preload; as=style, <${JSPATH}>; rel=preload; as=script`);
   }

--- a/public/sw.js
+++ b/public/sw.js
@@ -38,6 +38,7 @@ const SHELL_URL = '/.app/shell';
 const OFFLINE = [
   OFFLINE_URL,
   SHELL_URL,
+  '/?cacheOnly=true',
   '/favicons/android-chrome-72x72.png',
   '/manifest.json',
   '/img/GitHub-Mark-Light-24px.png',
@@ -49,15 +50,6 @@ const OFFLINE = [
 
 toolbox.precache(OFFLINE.concat(ASSETS));
 toolbox.options.cache.name = CACHE_NAME;
-
-// Cache the page registering the service worker. Without this, the
-// "first" page the user visits is only cached on the second visit,
-// since the first load is uncontrolled.
-toolbox.precache(
-  clients.matchAll({includeUncontrolled: true}).then(l => {
-    return l.map(c => c.url);
-  })
-);
 
 /**
  * Utility method to retrieve a url from the `toolbox.options.cache.name` cache


### PR DESCRIPTION
- Don't add the preload header of things in /.app/
- Don't cache the full page, as the next request will be served
  using shell.
- Precache the content for the start page.