### PR TITLE
Fixes showing double headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "sw-offline-google-analytics": "^1.1.1",
     "sw-toolbox": "^3.2.1",
     "urijs": "^1.18.1",
+    "url-polyfill": "^1.0.5",
     "whatwg-fetch": "^2.0.1",
     "yaku": "^0.17.6"
   },

--- a/public/js/routing/route.js
+++ b/public/js/routing/route.js
@@ -15,6 +15,8 @@
 
 /* eslint-env browser */
 
+import 'url-polyfill/url-polyfill';
+
 export default class Route {
   constructor(matchRegex, transitionStrategy, onAttached) {
     this._transitionStrategy = transitionStrategy;
@@ -46,6 +48,8 @@ export default class Route {
   }
 
   getContentOnlyUrl(url) {
-    return url + (url.indexOf('?') >= 0 ? '&' : '?') + 'contentOnly=true';
+    const u = new URL(url);
+    u.searchParams.append('contentOnly', 'true');
+    return u.toString();
   }
 }


### PR DESCRIPTION
- Adds a polyfill for the URL Api (Not supported in IE and
  URLSearchParams not supported in IE and Edge))
- Changes the getContentOnly method on the route to use the
  URL Api

Fixes #403 