### PR TITLE
Start App Shell content request from the Service Worker

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -78,8 +78,19 @@ const gulliverHandler = (request, values, options) => {
     });
 };
 
+const getContentOnlyUrl = url => {
+  const u = new URL(url);
+  u.searchParams.append('contentOnly', 'true');
+  return u.toString();
+};
+
 toolbox.router.default = (request, values, options) => {
   if (request.mode === 'navigate') {
+    // Launch and early request to the content URL that will be loaded from the shell.
+    // Since the response has a short timeout, the browser will re-use the request.
+    toolbox.cacheFirst(new Request(getContentOnlyUrl(request.url)), values, options);
+
+    // Replace the request with the App Shell.
     return getFromCache(SHELL_URL)
       .then(response => response || gulliverHandler(request, values, options));
   }


### PR DESCRIPTION
- Adds a request for the content that will be loaded from the
  AppShell when serving it from the Service Worker. This causes
  the request to start before the Javascript is parsed, speeding
  up content by 250 / 300ms when loaded in the first load happens
  in the App Shell.