### PR TITLE
use encodedUrl instead of ID for nav

### DIFF
--- a/controllers/pwa.js
+++ b/controllers/pwa.js
@@ -138,7 +138,7 @@ router.post('/add', (req, res, next) => {
  * Display a PWA or redirects to the encodedStartUrl of the PWA.
  */
 router.get('/:pwa', (req, res, next) => {
-  if (isNaN(+req.params.pwa)) {
+  if (isNaN(Number(req.params.pwa))) {
     // This URL is not a number, assume encodedStartUrl.
     renderOnePwa(req, res)
       .then(html => {

--- a/controllers/pwa.js
+++ b/controllers/pwa.js
@@ -153,7 +153,7 @@ router.get('/:pwa', (req, res, next) => {
 
   // Otherwise, redirect to /pwas/<encodedStartUrl>.
   pwaLib.find(req.params.pwa).then(pwa => {
-    res.redirect(req.baseUrl + '/' + pwa.encodedStartUrl);
+    res.redirect(301, req.baseUrl + '/' + pwa.encodedStartUrl);
   }).catch(err => {
     err.status = 404;
     return next(err);

--- a/controllers/pwa.js
+++ b/controllers/pwa.js
@@ -148,15 +148,16 @@ router.get('/:pwa', (req, res, next) => {
         err.status = 404;
         return next(err);
       });
-  } else {
-    // Otherwise, redirect to /pwas/<encodedStartUrl>.
-    pwaLib.find(req.params.pwa).then(pwa => {
-      res.redirect(req.baseUrl + '/' + pwa.encodedStartUrl);
-    }).catch(err => {
-      err.status = 404;
-      return next(err);
-    });
+    return;
   }
+
+  // Otherwise, redirect to /pwas/<encodedStartUrl>.
+  pwaLib.find(req.params.pwa).then(pwa => {
+    res.redirect(req.baseUrl + '/' + pwa.encodedStartUrl);
+  }).catch(err => {
+    err.status = 404;
+    return next(err);
+  });
 });
 
 /**

--- a/controllers/pwa.js
+++ b/controllers/pwa.js
@@ -135,17 +135,28 @@ router.post('/add', (req, res, next) => {
 /**
  * GET /pwas/:id
  *
- * Display a PWA.
+ * Display a PWA or redirects to the encodedStartUrl of the PWA.
  */
 router.get('/:pwa', (req, res, next) => {
-  renderOnePwa(req, res)
-    .then(html => {
-      res.send(html);
-    })
-    .catch(err => {
+  if (isNaN(+req.params.pwa)) {
+    // This URL is not a number, assume encodedStartUrl.
+    renderOnePwa(req, res)
+      .then(html => {
+        res.send(html);
+      })
+      .catch(err => {
+        err.status = 404;
+        return next(err);
+      });
+  } else {
+    // Otherwise, redirect to /pwas/<encodedStartUrl>.
+    pwaLib.find(req.params.pwa).then(pwa => {
+      res.redirect(req.baseUrl + '/' + pwa.encodedStartUrl);
+    }).catch(err => {
       err.status = 404;
       return next(err);
     });
+  }
 });
 
 /**
@@ -153,9 +164,9 @@ router.get('/:pwa', (req, res, next) => {
  */
 function renderOnePwa(req, res) {
   const url = req.originalUrl;
-  const pwaId = req.params.pwa;
+  const pwaId = encodeURIComponent(req.params.pwa);  // we have foo/ here, need foo%2F
   const contentOnly = false || req.query.contentOnly;
-  return pwaLib.find(pwaId)
+  return pwaLib.findByEncodedStartUrl(pwaId)
     .then(pwa => {
       return lighthouseLib.findByPwaId(pwaId)
         .then(lighthouse => {

--- a/public/js/gulliver.es6.js
+++ b/public/js/gulliver.es6.js
@@ -103,8 +103,8 @@ class Gulliver {
       charts.forEach(chart => new Chart(generateChartConfig(chart)).load());
     };
 
-    // Route for `/pwas/[id]`.
-    this._addRoute(/\/pwas\/(\d+)/, transitionStrategy, setupCharts, {
+    // Route for `/pwas/[id]`. Match allowed characters from encodeURIComponent.
+    this._addRoute(/\/pwas\/[\w\-\.!~*'()%]+/, transitionStrategy, setupCharts, {
       showTabs: false,
       backlink: true,
       subtitle: false

--- a/public/js/gulliver.es6.js
+++ b/public/js/gulliver.es6.js
@@ -103,8 +103,8 @@ class Gulliver {
       charts.forEach(chart => new Chart(generateChartConfig(chart)).load());
     };
 
-    // Route for `/pwas/[id]`. Match allowed characters from encodeURIComponent.
-    this._addRoute(/\/pwas\/[\w\-\.!~*'()%]+/, transitionStrategy, setupCharts, {
+    // Route for `/pwas/[id]`. Allow most characters (but will only ever be encodedURIComponent).
+    this._addRoute(/\/pwas\/.+/, transitionStrategy, setupCharts, {
       showTabs: false,
       backlink: true,
       subtitle: false

--- a/views/pwas/list.hbs
+++ b/views/pwas/list.hbs
@@ -32,7 +32,7 @@
 
         <div class="items">
             {{#each pwas}}
-            <a id="{{id}}" class="item card-pwa offline-aware gulliver-content-only box-shadow" href="/pwas/{{id}}" style="background-color: {{backgroundColor}}; color:{{contrastColor backgroundColor}}">
+            <a id="{{id}}" class="item card-pwa offline-aware gulliver-content-only box-shadow" href="/pwas/{{encodedStartUrl}}" style="background-color: {{backgroundColor}}; color:{{contrastColor backgroundColor}}">
             {{#if iconUrl64}}
                 <img class="pwa-icon" src="{{iconUrl64}}" srcset="{{iconUrl64}} 1x, {{iconUrl128}} 2x" width="64" height="64" alt="logo for {{displayName}}"/>
             {{else}}


### PR DESCRIPTION
Super naïve approach to #224. This changes all URLs to the encodedUrl version and redirects from numeric IDs.

(There also seems to be no nav tests, that's fine, just couldn't update anything)

Downsides-
- slower than ID lookup (always a query)
- top-level domains all end with %2F, which is a bit ugly: e.g., "santatracker.google.com/" => "santatracker.google.com%2F"