### PR TITLE
Fixes double-header on 404 pages

### DIFF
--- a/app.js
+++ b/app.js
@@ -118,7 +118,8 @@ app.use(require('./controllers'));
 
 // If no route has matched, return 404
 app.use((req, res) => {
-  res.status(404).render('404.hbs', {nonce1: req.nonce1, nonce2: req.nonce2});
+  res.status(404).render('404.hbs', 
+    {nonce1: req.nonce1, nonce2: req.nonce2, contentOnly: req.query.contentOnly || false});
 });
 
 // Basic error handler

--- a/views/404.hbs
+++ b/views/404.hbs
@@ -11,18 +11,24 @@
  See the License for the specific language governing permissions and
  limitations under the License. -->
 
+{{#unless contentOnly}}
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Gulliver - PWA Directory - File Not Found</title>
-
     {{> head}}
   </head>
   <body>
-    {{> header}}    
-    <div class="section-title">File Not Found</div>
-    <main>
-    </main>
+    {{> header}}
+    <div class="page-holder">
+      <main class="page">
+{{/unless}}
+    <div class="section-title">Page Not Found</div>
+{{#unless contentOnly}}
+      </main>
+      <div class='page-loader'>
+      </div>
+    </div>
     {{> footer}}
   </body>
 </html>
+{{/unless}}


### PR DESCRIPTION
- Makes 404.hbs compatible with the contentOnly templates
- Change app.js to pass the contentOnly parameter to 404.hbs