### PR TITLE
Changes non-linkable headers to grey

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -322,10 +322,15 @@ a.card-pwa:hover {
   border-radius: 2px;
 }
 .detail-general h3 { 
-  color: #1976D2;
+  color: #333333;
   margin: 0;
   padding: 16px;
 }
+
+.detail-general a {
+  color: #1976D2;
+}
+
 .detail-general h3 > .score {
   float: right;
 }


### PR DESCRIPTION
Headers in blue could be mistaken by links. Changed the color to
dark grey to avoid this. The Manifest section that is linkable
continues to be blue.

Fixes #406 