### PR TITLE
Change createOrUpdatePwa order to improve ux response

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@
 /public/js/gulliver.js
 /public/js/lighthouse-chart.js
 /public/js/pwa-form.js
+/lighthouse_machine

--- a/lib/pwa.js
+++ b/lib/pwa.js
@@ -187,9 +187,9 @@ exports.createOrUpdatePwa = function(pwa) {
     this.validatePwa,
     this.updatePwaManifest,
     this.savePwa,
-    this.updatePwaMetadataDescription,
     this.updatePwaIcon,
     this.savePwa,
+    this.removePwaFromCache,
     savedPwa => {
       // In background
       libPwaIndex.updateSearchIndex(savedPwa);
@@ -211,6 +211,7 @@ exports.getPwaPerformanceInfo = function(pwa) {
   setTimeout(_ => {
     return promiseSequential.all([
       _ => (pwa),
+      this.updatePwaMetadataDescription,
       this.updatePwaLighthouseInfo,
       this.updatePwaPageSpeedInformation,
       this.updatePwaWebPageTestInformation,

--- a/test/app/lib/pwa.js
+++ b/test/app/lib/pwa.js
@@ -205,12 +205,13 @@ describe('lib.pwa', () => {
       simpleMock.mock(libPwa, 'sendNewAppNotification').resolveWith(pwa);
       simpleMock.mock(libPwa, 'savePwa').resolveWith(pwa);
       simpleMock.mock(libPwa, 'submitWebPageUrlForWebPerformanceInformation').resolveWith(pwa);
+      simpleMock.mock(libPwa, 'removePwaFromCache').resolveWith(pwa);
       simpleMock.mock(promiseSequential, 'all');
       return libPwa.createOrUpdatePwa(pwa).should.be.fulfilled.then(result => {
         assert.equal(libPwa.updatePwaManifest.callCount, 1);
-        assert.equal(libPwa.updatePwaMetadataDescription.callCount, 1);
         assert.equal(libPwa.updatePwaIcon.callCount, 1);
         assert.equal(libPwa.savePwa.callCount, 2);
+        assert.equal(libPwa.removePwaFromCache.callCount, 1);
         assert.equal(promiseSequential.all.callCount, 1);
         assert.equal(result, pwa);
         assert.equal(libPwa.submitWebPageUrlForWebPerformanceInformation.callCount, 1);


### PR DESCRIPTION
1. Moves updatePwaMetadataDescription to the async section
2. Invalidates cache twice to have a fresher list page
