### PR TITLE
Adding readiness_checks

### DIFF
--- a/lighthouse_machine/app.yaml
+++ b/lighthouse_machine/app.yaml
@@ -30,9 +30,18 @@ handlers:
   script: IGNORED
   secure: always
 
-health_check:
-  enable_health_check: True
-  check_interval_sec: 10
-  timeout_sec: 10
-  unhealthy_threshold: 2
-  healthy_threshold: 2
+liveness_check:
+   path: '/_ah/health'
+   check_interval_sec: 30
+   timeout_sec: 4
+   failure_threshold: 3
+   success_threshold: 2
+   initial_delay_sec: 60
+
+readiness_check:
+  path: '/_ah/busy'
+  check_interval_sec: 3
+  timeout_sec: 2
+  failure_threshold: 1
+  success_threshold: 1
+  app_start_timeout_sec: 300

--- a/lighthouse_machine/server.js
+++ b/lighthouse_machine/server.js
@@ -109,6 +109,15 @@ app.get('/_ah/health', (req, res) => {
   }
 });
 
+// Busy-ness endpoit
+app.get('/_ah/busy', (req, res) => {
+  if (isBusy) {
+    res.sendStatus(503);
+  } else {
+    res.sendStatus(200);
+  }
+});
+
 http.createServer(app).listen(HTTP_PORT);
 https.createServer(options, app).listen(HTTPS_PORT);
 


### PR DESCRIPTION
Added readiness checks which allow for much better control of the status of the different containers (load balancer will not send new requests to busy instances)

https://cloud.google.com/appengine/docs/flexible/java/configuring-your-app-with-app-yaml#updated_health_checks